### PR TITLE
Symfony webpack encore integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/framework-bundle": "^5.0",
         "nyholm/psr7": "^1.2",
         "doctrine/mongodb-odm-bundle": "^4.1",
-        "blackfire/php-sdk": "^1.21"
+        "blackfire/php-sdk": "^1.21",
+        "symfony/webpack-encore-bundle": "^1.7"
     }
 }

--- a/src/DependencyInjection/BaldinofRoadRunnerExtension.php
+++ b/src/DependencyInjection/BaldinofRoadRunnerExtension.php
@@ -9,6 +9,7 @@ use Baldinof\RoadRunnerBundle\EventListener\SentryListener;
 use Baldinof\RoadRunnerBundle\Http\Middleware\BlackfireMiddleware;
 use Baldinof\RoadRunnerBundle\Http\Middleware\NativeSessionMiddleware;
 use Baldinof\RoadRunnerBundle\Http\Middleware\SentryMiddleware;
+use Baldinof\RoadRunnerBundle\Http\Middleware\WebpackEncoreMiddleware;
 use Baldinof\RoadRunnerBundle\Worker\Configuration as WorkerConfiguration;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -123,6 +124,12 @@ class BaldinofRoadRunnerExtension extends Extension
                 ->register(DoctrineMongoDBListener::class)
                 ->addArgument(new Reference('service_container'))
                 ->setAutoconfigured(true);
+        }
+
+        if (isset($bundles['WebpackEncoreBundle'])) {
+            $container->autowire(WebpackEncoreMiddleware::class);
+
+            $beforeMiddlewares[] = WebpackEncoreMiddleware::class;
         }
 
         $beforeMiddlewares[] = NativeSessionMiddleware::class;

--- a/src/Http/Middleware/WebpackEncoreMiddleware.php
+++ b/src/Http/Middleware/WebpackEncoreMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
+
+final class WebpackEncoreMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var EntrypointLookupInterface
+     */
+    private $entrypointLookup;
+
+    public function __construct(EntrypointLookupInterface $entrypointLookup)
+    {
+        $this->entrypointLookup = $entrypointLookup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $this->entrypointLookup->reset();
+
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
Hi,

this PR add integration with [symfony webpack encore bundle](https://github.com/symfony/webpack-encore-bundle), without this middleware `encore_entry_script_tags`, `encore_entry_link_tags`, etc methods, work only for first query, and after 2nd query return empty data.
