### PR TITLE
Inject 'kernel' service in KernelHandler

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,6 +28,8 @@ services:
 
   Baldinof\RoadRunnerBundle\Http\KernelHandler:
     autowire: true
+    arguments:
+      $kernel: '@kernel'
 
   Baldinof\RoadRunnerBundle\Http\MiddlewareStack:
     arguments: [ '@Baldinof\RoadRunnerBundle\Http\KernelHandler' ]


### PR DESCRIPTION
The `KernelHandler` is typehinted with `Symfony\Component\HttpKernel\HttpKernelInterface` so 
Symfony was injecting the service `http_kernel`. 

But only the `kernel` service calls the `service_resetter` on each `handle()` call.

