### PR TITLE
Fix metrics factory behavior

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -53,6 +53,7 @@ services:
       autowire: true
       arguments:
         $rrRpc: '%env(default::RR_RPC)%'
+        $rrEnabled: '%env(bool:default::RR)%'
         $metricsEnabled: '%baldinof_road_runner.metrics_enabled%'
         $kernelProjectDir: '%kernel.project_dir%'
 

--- a/src/Metric/MetricFactory.php
+++ b/src/Metric/MetricFactory.php
@@ -28,16 +28,22 @@ final class MetricFactory
      */
     private $kernelProjectDir;
 
-    public function __construct(?string $rrRpc, string $kernelProjectDir, bool $metricsEnabled)
+    /**
+     * @var bool|null
+     */
+    private $rrEnabled;
+
+    public function __construct(?string $rrRpc, ?bool $rrEnabled, string $kernelProjectDir, bool $metricsEnabled)
     {
         $this->rrRpc = $rrRpc;
+        $this->rrEnabled = $rrEnabled;
         $this->kernelProjectDir = $kernelProjectDir;
         $this->metricsEnabled = $metricsEnabled;
     }
 
     public function getMetricService(): MetricsInterface
     {
-        if (!$this->metricsEnabled) {
+        if (!$this->metricsEnabled || !$this->rrEnabled) {
             return new NullMetrics();
         }
 

--- a/tests/Metric/MetricFactoryTest.php
+++ b/tests/Metric/MetricFactoryTest.php
@@ -13,16 +13,22 @@ use Spiral\RoadRunner\MetricsInterface;
 
 class MetricFactoryTest extends TestCase
 {
+    public function test_is_metrics_enabled_but_run_without_rr(): void
+    {
+        $metricFactory = new MetricFactory(null, false, '', true);
+        $this->assertInstanceOf(NullMetrics::class, $metricFactory->getMetricService());
+    }
+
     public function test_is_metrics_enabled_but_rpc_not_configured(): void
     {
-        $metricFactory = new MetricFactory(null, '', true);
+        $metricFactory = new MetricFactory(null, true, '', true);
         $this->expectException(BadConfigurationException::class);
         $metricFactory->getMetricService();
     }
 
     public function test_is_null_metrics_created_when_metrics_disabled()
     {
-        $metricFactory = new MetricFactory(null, '', false);
+        $metricFactory = new MetricFactory(null, true, '', false);
         $this->assertInstanceOf(NullMetrics::class, $metricFactory->getMetricService());
     }
 
@@ -31,7 +37,7 @@ class MetricFactoryTest extends TestCase
      */
     public function test_correct_dsn(string $dsn)
     {
-        $metricFactory = new MetricFactory($dsn, '', true);
+        $metricFactory = new MetricFactory($dsn, true, '', true);
         $this->assertInstanceOf(MetricsInterface::class, $metricFactory->getMetricService());
     }
 
@@ -51,7 +57,7 @@ class MetricFactoryTest extends TestCase
      */
     public function test_wrong_rpc_dsn(string $dsn)
     {
-        $metricFactory = new MetricFactory($dsn, '', true);
+        $metricFactory = new MetricFactory($dsn, true, '', true);
         $this->expectException(UnknownRpcTransportException::class);
         $metricFactory->getMetricService();
     }


### PR DESCRIPTION
Hi,

in #3 I broke capability with cli interface, when RR metrics enabled. 
This PR fix metrics factory behavior.

User case:
1. I have application, that configured in that way: `baldinof_road_runner.metrics_enabled: true`
2. When I run it from roadrunner everything works perfect
3. If I try run it from cli (e.g. console command from application), it will be without RR_RPC variable, and will throw exception.