### PR TITLE
Allow to use `StreamedResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Disable default StreamedResponseListener to prevent early send. See https://github.com/Baldinof/roadrunner-bundle/issues/9
 
 ## [1.2.1] - 2020-04-24
 ### Added

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -61,3 +61,9 @@ services:
 
   Spiral\RoadRunner\MetricsInterface:
       factory: ['@Baldinof\RoadRunnerBundle\Metric\MetricFactory', 'getMetricService' ]
+
+  Baldinof\RoadRunnerBundle\EventListener\StreamedResponseListener:
+      decorates: streamed_response_listener
+      arguments:
+        $symfonyListener: '@Baldinof\RoadRunnerBundle\EventListener\StreamedResponseListener.inner'
+        $rrEnabled: '%env(bool:default::RR)%'

--- a/src/EventListener/StreamedResponseListener.php
+++ b/src/EventListener/StreamedResponseListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\StreamedResponseListener as SymfonyStreamedResponseListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * This listener decorates the default Symfony StreamedResponseListener and
+ * disables it when running RoadRunner workers.
+ *
+ * This is to prevent the response frome being sent by the listener.
+ */
+final class StreamedResponseListener implements EventSubscriberInterface
+{
+    private $symfonyListener;
+    private $rrEnabled;
+
+    public function __construct(SymfonyStreamedResponseListener $symfonyListener, ?bool $rrEnabled)
+    {
+        $this->symfonyListener = $symfonyListener;
+        $this->rrEnabled = $rrEnabled;
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$this->rrEnabled) {
+            $this->symfonyListener->onKernelResponse($event);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', -1024],
+        ];
+    }
+}

--- a/tests/BaldinofRoadRunnerBundleTest.php
+++ b/tests/BaldinofRoadRunnerBundleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Baldinof\RoadRunnerBundle;
 
 use Baldinof\RoadRunnerBundle\BaldinofRoadRunnerBundle;
+use Baldinof\RoadRunnerBundle\EventListener\StreamedResponseListener;
 use Baldinof\RoadRunnerBundle\Http\Middleware\SentryMiddleware;
 use PHPUnit\Framework\TestCase;
 use Sentry\SentryBundle\SentryBundle;
@@ -50,6 +51,17 @@ class BaldinofRoadRunnerBundleTest extends TestCase
         $c = $k->getContainer()->get('test.service_container');
 
         $this->assertFalse($c->has(SentryMiddleware::class));
+    }
+
+    public function test_it_decorates_StreamedResponseListener()
+    {
+        $k = $this->getKernel([], []);
+
+        $k->boot();
+
+        $c = $k->getContainer()->get('test.service_container');
+
+        $this->assertInstanceOf(StreamedResponseListener::class, $c->get('streamed_response_listener'));
     }
 
     public function getKernel(array $config, array $extraBundles)

--- a/tests/EventListener/StreamedResponseListenerTest.php
+++ b/tests/EventListener/StreamedResponseListenerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Baldinof\RoadRunnerBundle\EventListener;
+
+use Baldinof\RoadRunnerBundle\EventListener\StreamedResponseListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\StreamedResponseListener as SymfonyStreamedResponseListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class StreamedResponseListenerTest extends TestCase
+{
+    /**
+     * @testWith [ true, false ]
+     *           [ false, true ]
+     */
+    public function test_it_calls_the_decorated_listener_if_needed(bool $rrEnabled, bool $responseShouldBeSent): void
+    {
+        $listener = new StreamedResponseListener(new SymfonyStreamedResponseListener(), $rrEnabled);
+
+        $responseSent = false;
+
+        $listener->onKernelResponse($this->responseEvent(function () use (&$responseSent) {
+            $responseSent = true;
+        }));
+
+        $this->assertEquals($responseShouldBeSent, $responseSent);
+    }
+
+    public function test_it_registers_listener_with_the_same_priority()
+    {
+        $providedEvents = StreamedResponseListener::getSubscribedEvents();
+        $symfonyProvidedEvents = SymfonyStreamedResponseListener::getSubscribedEvents();
+
+        $this->assertEquals(
+            $symfonyProvidedEvents[KernelEvents::RESPONSE][1],
+            $providedEvents[KernelEvents::RESPONSE][1]
+        );
+    }
+
+    private function responseEvent(callable $streamedResponseCallback): ResponseEvent
+    {
+        return new ResponseEvent(
+            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            Request::create('http://example.org'),
+            HttpKernelInterface::MASTER_REQUEST,
+            new StreamedResponse($streamedResponseCallback)
+        );
+    }
+}


### PR DESCRIPTION
It disables Symfony default `StreamedResponseListener` that
sends the response before `Kernel::handle()` returns the response
and prevent psr-message-bridge to properly converts the symfony response
into a PSR response.

The default listener is still called when not in a roadrunner worker process.

Fixes #9 