### PR TITLE
Doctrine orm reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ baldinof_road_runner:
   default_integrations: false
 ```
 
+## Doctrine connection handler
+Due to the fact that roadrunner assumes that the process works in demonized mode, there may be problems with disconnecting the database, this problem is handled in this bundle if a doctrine is used to connect to the database.
+
+By default, in the event of a connection failure, the process will be stopped and the request will end with a 500 http code, to prevent this and to correctly process failed connections, without erroneous answers - you need to add [symfony/proxy-manager-bridge](https://github.com/symfony/proxy-manager-bridge) to your project:
+```
+composer require symfony/proxy-manager-bridge
+```
+
+## Sessions in database
+In accordance with the problem described above, to store sessions in the database, you should use the doctrine connection, for example, you can use the [shapecode/doctrine-session-handler-bundle](https://github.com/shapecode/doctrine-session-handler-bundle) bundle
+
+```
+composer require shapecode/doctrine-session-handler-bundle
+```
+
 ## Middlewares
 
 You can use middlewares to manipulate PSR request & responses. Middlewares can implements either PSR [`MiddlewareInterface`](https://www.php-fig.org/psr/psr-15/#22-psrhttpservermiddlewareinterface)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "dflydev/fig-cookies": "^2.0",
-        "symfony/proxy-manager-bridge": "^5.0"
+        "symfony/proxy-manager-bridge": "^4.0 || ^5.0"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "dflydev/fig-cookies": "^2.0"
+        "dflydev/fig-cookies": "^2.0",
+        "symfony/proxy-manager-bridge": "^5.0"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
@@ -42,7 +43,9 @@
         "symfony/framework-bundle": "^4.0||^5.0",
         "nyholm/psr7": "^1.2",
         "doctrine/mongodb-odm-bundle": "^4.1",
-        "blackfire/php-sdk": "^1.21"
+        "blackfire/php-sdk": "^1.21",
+        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/orm": "^2.7"
     },
     "scripts": {
         "test": "phpunit --testdox --colors=always",

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "dflydev/fig-cookies": "^2.0",
-        "symfony/proxy-manager-bridge": "^4.0 || ^5.0"
+        "dflydev/fig-cookies": "^2.0"
     },
     "suggest": {
-        "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
+        "nyholm/psr7": "For a super lightweight PSR-7/17 implementation",
+        "symfony/proxy-manager-bridge": "For doctrine re-connection implementation"
     },
     "require-dev": {
         "symfony/var-dumper": "^4.0||^5.0",
@@ -45,7 +45,8 @@
         "doctrine/mongodb-odm-bundle": "^4.1",
         "blackfire/php-sdk": "^1.21",
         "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/orm": "^2.7"
+        "doctrine/orm": "^2.7",
+        "symfony/proxy-manager-bridge": "^4.0 || ^5.0"
     },
     "scripts": {
         "test": "phpunit --testdox --colors=always",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,7 @@ services:
     public: true
 
   Baldinof\RoadRunnerBundle\Http\Middleware\NativeSessionMiddleware: null
+  Baldinof\RoadRunnerBundle\Http\Middleware\DoctrineMiddleware: null
 
   baldinof_roadrunner.http_foundation_factory:
     class: 'Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory'

--- a/src/DependencyInjection/BaldinofRoadRunnerExtension.php
+++ b/src/DependencyInjection/BaldinofRoadRunnerExtension.php
@@ -7,6 +7,7 @@ use Baldinof\RoadRunnerBundle\EventListener\ConfigureVarDumperListener;
 use Baldinof\RoadRunnerBundle\EventListener\DoctrineMongoDBListener;
 use Baldinof\RoadRunnerBundle\EventListener\SentryListener;
 use Baldinof\RoadRunnerBundle\Http\Middleware\BlackfireMiddleware;
+use Baldinof\RoadRunnerBundle\Http\Middleware\DoctrineMiddleware;
 use Baldinof\RoadRunnerBundle\Http\Middleware\NativeSessionMiddleware;
 use Baldinof\RoadRunnerBundle\Http\Middleware\SentryMiddleware;
 use Baldinof\RoadRunnerBundle\Worker\Configuration as WorkerConfiguration;
@@ -123,6 +124,11 @@ class BaldinofRoadRunnerExtension extends Extension
                 ->register(DoctrineMongoDBListener::class)
                 ->addArgument(new Reference('service_container'))
                 ->setAutoconfigured(true);
+        }
+
+        if (isset($bundles['DoctrineBundle'])) {
+            $container->autowire(DoctrineMiddleware::class);
+            $beforeMiddlewares[] = DoctrineMiddleware::class;
         }
 
         $beforeMiddlewares[] = NativeSessionMiddleware::class;

--- a/src/Http/Middleware/DoctrineMiddleware.php
+++ b/src/Http/Middleware/DoctrineMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Http\Middleware;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class DoctrineMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var ManagerRegistry
+     */
+    private $managerRegistry;
+
+    public function __construct(ManagerRegistry $managerRegistry)
+    {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        foreach ($this->managerRegistry->getManagers() as $name => $manager) {
+            assert($manager instanceof EntityManagerInterface);
+
+            /** @var \Doctrine\DBAL\Connection $connection */
+            $connection = $manager->getConnection();
+
+            if ($connection->isConnected()) {
+                if (false === $connection->ping()) {
+                    $connection->close();
+                    $connection->connect();
+                }
+
+                if (!$manager->isOpen()) {
+                    $this->managerRegistry->resetManager($name);
+                }
+            }
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Http/Middleware/DoctrineMiddleware.php
+++ b/src/Http/Middleware/DoctrineMiddleware.php
@@ -37,11 +37,6 @@ class DoctrineMiddleware implements MiddlewareInterface
             if ($connection->isConnected()) {
                 if (false === $connection->ping()) {
                     $connection->close();
-                    $connection->connect();
-                }
-
-                if (!$manager->isOpen()) {
-                    $this->managerRegistry->resetManager($name);
                 }
             }
         }

--- a/tests/Http/Middleware/DoctrineMiddlewareTest.php
+++ b/tests/Http/Middleware/DoctrineMiddlewareTest.php
@@ -47,22 +47,12 @@ class DoctrineMiddlewareTest extends TestCase
         $this->middleware->process($this->requestMock, $this->handlerMock);
     }
 
-    public function test_reset_closed_entity_manager(): void
-    {
-        $this->connectionMock->expects($this->once())->method('ping')->willReturn(true);
-        $this->entityManagerMock->expects($this->once())->method('isOpen')->willReturn(false);
-        $this->managerRegistryMock->expects($this->once())->method('resetManager');
-        $this->connectionMock->method('isConnected')->willReturn(true);
-        $this->middleware->process($this->requestMock, $this->handlerMock);
-    }
-
     public function test_reopen_not_respond_connection(): void
     {
         $this->connectionMock->expects($this->once())->method('ping')->willReturn(false);
-        $this->entityManagerMock->expects($this->once())->method('isOpen')->willReturn(true);
         $this->connectionMock->method('isConnected')->willReturn(true);
         $this->connectionMock->expects($this->once())->method('close');
-        $this->connectionMock->expects($this->once())->method('connect');
+        $this->connectionMock->expects($this->never())->method('connect');
         $this->middleware->process($this->requestMock, $this->handlerMock);
     }
 }

--- a/tests/Http/Middleware/DoctrineMiddlewareTest.php
+++ b/tests/Http/Middleware/DoctrineMiddlewareTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Baldinof\RoadRunnerBundle\Http\Middleware;
+
+use Baldinof\RoadRunnerBundle\Http\Middleware\DoctrineMiddleware;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class DoctrineMiddlewareTest extends TestCase
+{
+    private $managerRegistryMock;
+    private $entityManagerMock;
+    private $connectionMock;
+    private $requestMock;
+    private $handlerMock;
+    private $middleware;
+
+    public function setUp(): void
+    {
+        $this->managerRegistryMock = $this->createMock(ManagerRegistry::class);
+        $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $this->connectionMock = $this->createMock(Connection::class);
+
+        $this->entityManagerMock->method('getConnection')->willReturn($this->connectionMock);
+        $this->managerRegistryMock->method('getManagers')->willReturn([$this->entityManagerMock]);
+
+        $this->requestMock = $this->createMock(ServerRequestInterface::class);
+        $this->handlerMock = $this->createMock(RequestHandlerInterface::class);
+        $this->middleware = new DoctrineMiddleware($this->managerRegistryMock);
+    }
+
+    public function test_skip_when_not_connected(): void
+    {
+        $this->connectionMock->method('isConnected')->willReturn(false);
+        $this->connectionMock->expects($this->never())->method('ping');
+        $this->connectionMock->expects($this->never())->method('connect');
+        $this->connectionMock->expects($this->never())->method('connect');
+
+        $this->managerRegistryMock->expects($this->never())->method('resetManager');
+
+        $this->middleware->process($this->requestMock, $this->handlerMock);
+    }
+
+    public function test_reset_closed_entity_manager(): void
+    {
+        $this->connectionMock->expects($this->once())->method('ping')->willReturn(true);
+        $this->entityManagerMock->expects($this->once())->method('isOpen')->willReturn(false);
+        $this->managerRegistryMock->expects($this->once())->method('resetManager');
+        $this->connectionMock->method('isConnected')->willReturn(true);
+        $this->middleware->process($this->requestMock, $this->handlerMock);
+    }
+
+    public function test_reopen_not_respond_connection(): void
+    {
+        $this->connectionMock->expects($this->once())->method('ping')->willReturn(false);
+        $this->entityManagerMock->expects($this->once())->method('isOpen')->willReturn(true);
+        $this->connectionMock->method('isConnected')->willReturn(true);
+        $this->connectionMock->expects($this->once())->method('close');
+        $this->connectionMock->expects($this->once())->method('connect');
+        $this->middleware->process($this->requestMock, $this->handlerMock);
+    }
+}


### PR DESCRIPTION
Hi,

I found few problem when works with doctrine:
1. if connections to database closed - it will never up again, until worker is stoped
2. if entity manager closed - it will never open again, until worker is stoped

this PR fix described behavior