### PR TITLE
Clear Sentry breadcrumbs at the end of every request

### DIFF
--- a/src/Http/Middleware/SentryMiddleware.php
+++ b/src/Http/Middleware/SentryMiddleware.php
@@ -63,6 +63,7 @@ final class SentryMiddleware implements IteratorMiddlewareInterface
         $options = $client->getOptions();
 
         $this->hub->configureScope(function (Scope $scope) use ($request, $options) {
+            $scope->clear();
             $scope->addEventProcessor(function (Event $event) use ($request, $options) {
                 $this->processEvent($event, $options, $request);
 


### PR DESCRIPTION
We are seeing breadcrumbs from previous requests on our traces in Sentry, this makes it less useful for debugging and also causes the memory usage to increase between requests.