### PR TITLE
Fix deprecation warning on "Symfony\Component\Config\Definition\Builder\NodeDefinition::setDeprecated()"

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('should_reboot_kernel')
                     ->defaultFalse()
-                    ->setDeprecated('Configuration "%path%" is deprecated in favor of "baldinor_road_runner.kernel_reboot_strategy"')
+                    ->setDeprecated('baldinof/roadrunner-bundle', '1.3.0', 'Configuration "%path%" is deprecated in favor of "baldinor_road_runner.kernel_reboot_strategy"')
                 ->end()
                 ->booleanNode('default_integrations')->defaultTrue()->end()
                 ->booleanNode('metrics_enabled')->defaultFalse()->end()


### PR DESCRIPTION
```
The signature of method "Symfony\Component\Config\Definition\Builder\NodeDefinition::setDeprecated()" requires 3 arguments: "string $package, string $version, string $message", not defining them is deprecated
```