### PR TITLE
Create Symfony UploadedFile in test mode

### DIFF
--- a/src/RoadRunnerBridge/HttpFoundationWorker.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker.php
@@ -163,7 +163,7 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
                 continue;
             }
 
-            $result[$index] = new UploadedFile($file['tmpName'] ?? '', $file['name'], $file['mime'], $file['error']);
+            $result[$index] = new UploadedFile($file['tmpName'] ?? '', $file['name'], $file['mime'], $file['error'], true);
         }
 
         return $result;

--- a/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
+++ b/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
@@ -134,6 +134,14 @@ class HttpFoundationWorkerTest extends TestCase
             fn (SymfonyRequest $request) => expect($request->files->get('error')->getError())
                 ->toBe(\UPLOAD_ERR_CANT_WRITE),
         ];
+
+        yield 'valid upload' => [
+            fn (RoadRunnerRequest $request) => $request->uploads = [
+                'doc1' => $this->createUploadedFile('Doc 1', \UPLOAD_ERR_OK, 'doc1.txt', 'text/plain'),
+            ],
+            fn (SymfonyRequest $request) => expect($request->files->get('doc1')->isValid())
+                ->toBeTrue(),
+        ];
     }
 
     /**


### PR DESCRIPTION
By default `UploadedFile` will check if the file is actually an uploads with `is_uploaded_file()`, but this functions always returns `false` in CLI.

As the uploads come from RoadRunner, we can simply disable this check.

Closes #37 