### PR TITLE
compatibility/middlewarestack

### DIFF
--- a/src/Http/MiddlewareStack.php
+++ b/src/Http/MiddlewareStack.php
@@ -64,7 +64,7 @@ final class Runner implements HttpKernelInterface
         $this->iterators = new SplStack();
     }
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
     {
         if ($this->middlewares->isEmpty()) {
             $gen = $this->handler->handle($request);


### PR DESCRIPTION
Add Response typehint to function handle to make it compatible with HttpKernelInterface on Symfony 6.0

https://github.com/symfony/http-kernel/blob/6.0/HttpKernelInterface.php#L45