### PR TITLE
Reduce composer package size by introducing .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.github export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.dist.php
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Some files and folders are not needed to run the package therefore they can be safely excluded.

`.gitattributes` are widely used, even symfony uses it in all of it's components