### PR TITLE
Remove deprecation messages for ODM integration and worker command

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,3 +18,5 @@ parameters:
           path: 'src/Integration/PHP/NativeSessionMiddleware.php'
         - message: '#Cannot cast mixed to string.#'
           path: 'src/Worker/Worker.php'
+        - message: '#Attribute class Symfony\\Component\\Console\\Attribute\\AsCommand does not exist.#'
+          path: 'src/Command/WorkerCommand.php'

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -6,11 +6,13 @@ namespace Baldinof\RoadRunnerBundle\Command;
 
 use Baldinof\RoadRunnerBundle\Worker\WorkerInterface;
 use Spiral\RoadRunner\Environment\Mode;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'baldinof:roadrunner:worker')]
 final class WorkerCommand extends Command
 {
     protected static $defaultName = 'baldinof:roadrunner:worker';

--- a/src/Integration/Doctrine/DoctrineODMListener.php
+++ b/src/Integration/Doctrine/DoctrineODMListener.php
@@ -62,7 +62,10 @@ final class DoctrineODMListener implements EventSubscriberInterface
         return null;
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::TERMINATE => 'onTerminate',


### PR DESCRIPTION
Hello! Thanks for the great library!
Symfony started complaining about outdated code, so here's a quick fix for that.

Please note that this fix requires the minimum PHP version to be increased to 8.0

I hope this problem will be fixed in the next major release.