### PR TITLE
Reset symfony services on every handled request

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Baldinof\RoadRunnerBundle\DependencyInjection\BaldinofRoadRunnerExtension;
+use Baldinof\RoadRunnerBundle\EventListener\ResetServicesListener;
 use Baldinof\RoadRunnerBundle\Grpc\GrpcServiceProvider;
 use Baldinof\RoadRunnerBundle\Helpers\RPCFactory;
 use Baldinof\RoadRunnerBundle\Http\KernelHandler;
@@ -98,6 +99,10 @@ return static function (ContainerConfigurator $container) {
         ->args([service(KernelHandler::class)]);
 
     $services->alias(RequestHandlerInterface::class, MiddlewareStack::class);
+
+    $services->set(ResetServicesListener::class)
+        ->args([service('services_resetter')])
+        ->tag('kernel.event_subscriber');
 
     if (interface_exists(GrpcServiceInterface::class)) {
         $services->set(GrpcServiceProvider::class);

--- a/src/Event/WorkerRequestHandledEvent.php
+++ b/src/Event/WorkerRequestHandledEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class WorkerRequestHandledEvent extends Event
+{
+}

--- a/src/EventListener/ResetServicesListener.php
+++ b/src/EventListener/ResetServicesListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\EventListener;
+
+use Baldinof\RoadRunnerBundle\Event\WorkerRequestHandledEvent;
+use Baldinof\RoadRunnerBundle\Event\WorkerStopEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+
+final class ResetServicesListener implements EventSubscriberInterface
+{
+    public function __construct(private ServicesResetter $servicesResetter)
+    {
+    }
+
+    public function resetServices(): void
+    {
+        $this->servicesResetter->reset();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerRequestHandledEvent::class => ['resetServices', -1024],
+            WorkerStopEvent::class => ['resetServices', -1024],
+        ];
+    }
+}

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -6,6 +6,7 @@ namespace Baldinof\RoadRunnerBundle\Worker;
 
 use Baldinof\RoadRunnerBundle\Event\WorkerExceptionEvent;
 use Baldinof\RoadRunnerBundle\Event\WorkerKernelRebootedEvent;
+use Baldinof\RoadRunnerBundle\Event\WorkerRequestHandledEvent;
 use Baldinof\RoadRunnerBundle\Event\WorkerStartEvent;
 use Baldinof\RoadRunnerBundle\Event\WorkerStopEvent;
 use Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorkerInterface;
@@ -107,6 +108,8 @@ final class HttpWorker implements WorkerInterface
                 $sent = true;
 
                 consumes($gen);
+
+                $this->dependencies->getEventDispatcher()->dispatch(new WorkerRequestHandledEvent());
             } catch (\Throwable $e) {
                 if (!$sent) {
                     $response = ($this->renderError)($e);


### PR DESCRIPTION
Add support for resetting container services after each handled request.

Without this patch, services are not resetted. For example Monolog's Finger Cross handler is never reset nor flushed. So if the first request triggers an "error" level message, all others message will log and overflow the buffer.

Even symfony's messenger component has such implementation for long running process: https://github.com/symfony/messenger/blob/6.2/EventListener/ResetServicesListener.php