### PR TITLE
Add centrifuge worker prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ baldinof_road_runner:
 ```
 
 
-## Events
+## HTTP worker Events
 
 The following events are dispatched throughout the worker lifecycle:
 
@@ -176,11 +176,147 @@ class YouController
 }
 ```
 
+## Centrifuge.js (websocket)
+Bundle supports Centrifuge websocket plugin for RoadRunner 2 using Symfony's
+event system. Configuration reference can be found at https://roadrunner.dev/docs/plugins-centrifuge.
+By default, worker will answer with empty/default corresponding responses for each Centrifuge websocket request.
+Every request type can be found at `Baldinof\RoadRunnerBundle\Event\Centrifuge` namespace. Be aware that you are bypassing
+a lot of Symfony's security checks, remember, this is not a HttpWorker
+
+Example usage
+
+```yaml
+service:
+  centrifuge:
+    command: "./bin/centrifuge --config=centrifuge.json" # you need to download the bin/centrifuge, just follow reference configuration link from RoadRunner docs
+    process_num: 1
+    remain_after_exit: true
+    service_name_in_log: true
+    restart_sec: 1
+
+centrifuge:
+  proxy_address: "tcp://127.0.0.1:10001"
+  grpc_api_address: "tcp://127.0.0.1:10000"
+  pool:
+    reset_timeout: 10
+    num_workers: 1
+    max_jobs: 1
+
+# centrifuge requires rpc plugin
+rpc:
+  listen: tcp://127.0.0.1:6001
+```
+
+centrifuge.json (in project root)
+```json5
+{
+  "allowed_origins": [
+    "*"
+  ],
+  "publish": true,
+  "proxy_publish": true,
+  "proxy_subscribe": true,
+  "proxy_connect": true,
+  "allow_subscribe_for_client": true,
+  "address": "127.0.0.1",  // use  0.0.0.0 if you are running RR in docker
+  "grpc_api": true,
+  "grpc_api_address": "127.0.0.1",  // use  0.0.0.0 if you are running RR in docker
+  "grpc_api_port": 10000,
+  "port": 8081, // exposed centrifuge port
+  "proxy_connect_endpoint": "grpc://127.0.0.1:10001",
+  "proxy_connect_timeout": "10s",
+  "proxy_publish_endpoint": "grpc://127.0.0.1:10001",
+  "proxy_publish_timeout": "10s",
+  "proxy_subscribe_endpoint": "grpc://127.0.0.1:10001",
+  "proxy_subscribe_timeout": "10s",
+  "proxy_refresh_endpoint": "grpc://127.0.0.1:10001",
+  "proxy_refresh_timeout": "10s",
+  "proxy_rpc_endpoint": "grpc://127.0.0.1:10001",
+  "proxy_rpc_timeout": "10s"
+}
+```
+
+docker-compose.yaml
+```yaml
+services:
+  app:
+    ports:
+      - "8080:8080" # your RoadRunner port
+      - "8081:8081" # centrifuge port
+```
+
+ConnectListener.php
+```php
+<?php
+
+namespace App\EventListener\Centrifuge;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\ConnectEvent;
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AsEventListener]
+readonly class ConnectListener
+{
+    public function __construct(private UserRepository $userRepository)
+    {
+    }
+
+    public function __invoke(ConnectEvent $event): void
+    {
+        $token = $event->getRequest()->getData()["token"] ?? null;
+        if ($token === null) {
+            $event->getRequest()->disconnect(Response::HTTP_FORBIDDEN, 'Missing user "token"');
+            $event->stopPropagation();
+            return;
+        }
+
+        $user = $this->userRepository->findOneBy(["token" => $token]);
+        if ($user === null) {
+            $event->getRequest()->disconnect(Response::HTTP_UNAUTHORIZED, 'Invalid user "token"');
+            $event->stopPropagation();
+            return;
+        }
+
+        $event->setResponse(new ConnectResponse(
+            user: $user->getId(),
+            channels: ["my_global_channel"],
+        ));
+    }
+}
+```
+
+publishing messages programmatically can be done by injecting `RoadRunner\Centrifugo\RPCCentrifugoApi`
+```php
+
+namespace App\Services;
+
+use RoadRunner\Centrifugo\RPCCentrifugoApi;
+
+readonly class MyService
+{
+    public function __construct(private RPCCentrifugoApi $centrifugoApi)
+    {
+    }
+
+    public function doSomething(): void
+    {
+        $this->centrifugoApi->publish("my_global_channel", json_encode([
+            "data" => "to_send",
+        ]));
+    }
+}
+```
+
+
 ## gRPC
 
 gRPC support was added by the roadrunner-grpc plugin for RoadRunner 2 (https://github.com/spiral/roadrunner-grpc).
 
-To configure Roadrunner for gRPC, refer to the configuration reference at https://roadrunner.dev/docs/beep-beep-grpc. Basic configuration example:
+To configure Roadrunner for gRPC, refer to the configuration reference at https://roadrunner.dev/docs/plugins-grpc/current. Basic configuration example:
 
 ```yaml
 server:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "spiral/roadrunner-worker": "^3.0.0",
         "spiral/goridge": "^4.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "spiral/roadrunner-http": "^3.0"
+        "spiral/roadrunner-http": "^3.0",
+        "roadrunner-php/centrifugo": "^2.0"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation",

--- a/src/Event/Centrifuge/CentrifugeEventInterface.php
+++ b/src/Event/Centrifuge/CentrifugeEventInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+
+interface CentrifugeEventInterface
+{
+    public function getResponse(): ?ResponseInterface;
+
+    public function getRequest(): RequestInterface;
+
+    public function setResponse(?ResponseInterface $response): self;
+}

--- a/src/Event/Centrifuge/ConnectEvent.php
+++ b/src/Event/Centrifuge/ConnectEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Request\Connect;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ConnectEvent extends Event implements CentrifugeEventInterface
+{
+    private ?ConnectResponse $response = null;
+
+    public function __construct(
+        private readonly Connect $request,
+    ) {
+    }
+
+    public function getRequest(): Connect
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?ConnectResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(ConnectResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Event/Centrifuge/InvalidEvent.php
+++ b/src/Event/Centrifuge/InvalidEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Request\Invalid;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class InvalidEvent extends Event implements CentrifugeEventInterface
+{
+    public function __construct(
+        private readonly Invalid $request,
+    ) {
+    }
+
+    public function getRequest(): Invalid
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return null;
+    }
+
+    public function setResponse(?ResponseInterface $response): CentrifugeEventInterface
+    {
+        throw new \RuntimeException('Setting response for invalid request is not supported');
+    }
+}

--- a/src/Event/Centrifuge/PublishEvent.php
+++ b/src/Event/Centrifuge/PublishEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\PublishResponse;
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Request\Publish;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PublishEvent extends Event implements CentrifugeEventInterface
+{
+    private ?PublishResponse $response = null;
+
+    public function __construct(
+        private readonly Publish $request,
+    ) {
+    }
+
+    public function getRequest(): Publish
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?PublishResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(PublishResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Event/Centrifuge/RPCEvent.php
+++ b/src/Event/Centrifuge/RPCEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Payload\RPCResponse;
+use RoadRunner\Centrifugo\Request\RPC;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class RPCEvent extends Event implements CentrifugeEventInterface
+{
+    private ?RPCResponse $response = null;
+
+    public function __construct(
+        private readonly RPC $request,
+    ) {
+    }
+
+    public function getRequest(): RPC
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?RPCResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(RPCResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Event/Centrifuge/RefreshEvent.php
+++ b/src/Event/Centrifuge/RefreshEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\RefreshResponse;
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Request\Refresh;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class RefreshEvent extends Event implements CentrifugeEventInterface
+{
+    private ?RefreshResponse $response = null;
+
+    public function __construct(
+        private readonly Refresh $request,
+    ) {
+    }
+
+    public function getRequest(): Refresh
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?RefreshResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(RefreshResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Event/Centrifuge/SubRefreshEvent.php
+++ b/src/Event/Centrifuge/SubRefreshEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Payload\SubRefreshResponse;
+use RoadRunner\Centrifugo\Request\SubRefresh;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SubRefreshEvent extends Event implements CentrifugeEventInterface
+{
+    private ?SubRefreshResponse $response = null;
+
+    public function __construct(
+        private readonly SubRefresh $request,
+    ) {
+    }
+
+    public function getRequest(): SubRefresh
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?SubRefreshResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(SubRefreshResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Event/Centrifuge/SubscribeEvent.php
+++ b/src/Event/Centrifuge/SubscribeEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Event\Centrifuge;
+
+use RoadRunner\Centrifugo\Payload\ResponseInterface;
+use RoadRunner\Centrifugo\Payload\SubscribeResponse;
+use RoadRunner\Centrifugo\Request\Subscribe;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SubscribeEvent extends Event implements CentrifugeEventInterface
+{
+    private ?SubscribeResponse $response = null;
+
+    public function __construct(
+        private readonly Subscribe $request,
+    ) {
+    }
+
+    public function getRequest(): Subscribe
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?SubscribeResponse
+    {
+        return $this->response;
+    }
+
+    public function setResponse(SubscribeResponse|ResponseInterface|null $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/src/Worker/CentrifugeWorker.php
+++ b/src/Worker/CentrifugeWorker.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Worker;
+
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\CentrifugeEventInterface;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\ConnectEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\InvalidEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\PublishEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\RefreshEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\RPCEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\SubRefreshEvent;
+use Baldinof\RoadRunnerBundle\Event\Centrifuge\SubscribeEvent;
+use Psr\Log\LoggerInterface;
+use RoadRunner\Centrifugo\CentrifugoWorker;
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use RoadRunner\Centrifugo\Payload\PublishResponse;
+use RoadRunner\Centrifugo\Payload\RefreshResponse;
+use RoadRunner\Centrifugo\Payload\RPCResponse;
+use RoadRunner\Centrifugo\Payload\SubRefreshResponse;
+use RoadRunner\Centrifugo\Payload\SubscribeResponse;
+use RoadRunner\Centrifugo\Request;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class CentrifugeWorker implements WorkerInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private CentrifugoWorker $centrifugoWorker,
+        private EventDispatcherInterface $eventDispatcher,
+        private HttpDependencies $httpDependencies,
+    ) {
+    }
+
+    public function start(): void
+    {
+        $this->logger->debug('Centrifuge worker started');
+
+        while ($request = $this->centrifugoWorker->waitRequest()) {
+            $eventClass = match (true) {
+                $request instanceof Request\Connect => ConnectEvent::class,
+                $request instanceof Request\Publish => PublishEvent::class,
+                $request instanceof Request\Refresh => RefreshEvent::class,
+                $request instanceof Request\SubRefresh => SubRefreshEvent::class,
+                $request instanceof Request\Subscribe => SubscribeEvent::class,
+                $request instanceof Request\RPC => RPCEvent::class,
+                $request instanceof Request\Invalid => InvalidEvent::class,
+                default => throw new \RuntimeException(sprintf("Unsupported \$request type '%s'", $request::class)),
+            };
+
+            $event = new $eventClass($request);
+
+            try {
+                $processedEvent = $this->eventDispatcher->dispatch($event);
+                \assert($processedEvent instanceof CentrifugeEventInterface);
+
+                $response = $processedEvent->getResponse() ?? match ($eventClass) {
+                    ConnectEvent::class => new ConnectResponse(),
+                    PublishEvent::class => new PublishResponse(),
+                    RefreshEvent::class => new RefreshResponse(),
+                    SubRefreshEvent::class => new SubRefreshResponse(),
+                    SubscribeEvent::class => new SubscribeResponse(),
+                    RPCEvent::class => new RPCResponse(),
+                    default => null,
+                };
+
+                if ($response !== null) {
+                    $request->respond($response);
+                }
+            } catch (\Throwable $throwable) {
+                $request->disconnect(500, 'Server error');
+
+                throw $throwable;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to implement support for Centrifuge worker https://roadrunner.dev/docs/plugins-centrifuge using symfony event dispatcher.

As it is, it works, but it should probably receive it's own middleware stack, mainly for doctrine and sentry. I am not sure about it's own kernel_reboots, I guess its also needed?

The centrifugo middleware will need to be separated from http middlewares, probably simply using different namespaces, so we do not touch http middlewares and keep the yaml config. Middlewares would then sort by the interface they implement.

If we do want to add kernel reboots, then we will need to change the yaml config structure, which could be breaking change if we want to make them universal