### PR TITLE
Add missing step in usage (Baldinof/roadrunner-bundle#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you don't use Symfony Flex:
 
 ## Usage
 
+- require the RoadRunner download utility: `composer require --dev spiral/roadrunner-cli`
 - get the RoadRunner binary: `vendor/bin/rr get --location bin/`
 - run RoadRunner with `bin/rr serve` or `bin/rr serve -c .rr.dev.yaml` (watch mode)
 - visit your app at http://localhost:8080

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation",
+        "spiral/roadrunner-cli": "For easy installation of RoadRunner",
         "symfony/proxy-manager-bridge": "For doctrine re-connection implementation"
     },
     "require-dev": {


### PR DESCRIPTION
Since 2023.X release, the binary download utility is no longer automatically included in RoadRunner.

I put this as a suggestion in composer.json rather than a requirement, as there are different options of getting RoadRunner, this being one of the most convenient ones, at least for local development.