### PR TITLE
Feat: support for RR in Docker behind proxy in another Docker

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -60,7 +60,10 @@ return static function (ContainerConfigurator $container) {
 
     // Bundle services
     $services->set(HttpFoundationWorkerInterface::class, HttpFoundationWorker::class)
-        ->args([service(HttpWorkerInterface::class)]);
+        ->args([
+            service(HttpWorkerInterface::class),
+            service(KernelRebootStrategyInterface::class),
+        ]);
 
     $services->set(WorkerRegistryInterface::class, WorkerRegistry::class)
         ->public();

--- a/src/RoadRunnerBridge/HttpFoundationWorker.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker.php
@@ -9,19 +9,41 @@ use Spiral\RoadRunner\Http\Request as RoadRunnerRequest;
 use Spiral\RoadRunner\WorkerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 {
     private HttpWorkerInterface $httpWorker;
     private array $originalServer;
+    private array $trustedHeaders;
 
-    public function __construct(HttpWorkerInterface $httpWorker)
+    public function __construct(
+        HttpWorkerInterface $httpWorker,
+        KernelInterface $kernel
+    )
     {
         $this->httpWorker = $httpWorker;
         $this->originalServer = $_SERVER;
+
+        $container = $kernel->getContainer();
+        if ($container->hasParameter('kernel.trusted_proxies') && $container->hasParameter('kernel.trusted_headers')) {
+            $trustedHeaders = $container->getParameter('kernel.trusted_headers');
+
+            $headerNames = [];
+
+            if ($trustedHeaders & Request::HEADER_X_FORWARDED_FOR) {
+                $headerNames[] = 'x-forwarded-for';
+            }
+            if ($trustedHeaders & Request::HEADER_X_FORWARDED_PROTO) {
+                $headerNames[] = 'x-forwarded-proto';
+            }
+
+            $this->trustedHeaders = $headerNames;
+        }
     }
 
     public function waitRequest(): ?SymfonyRequest
@@ -95,7 +117,11 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 
         $components = parse_url($request->uri);
 
-        $components["scheme"] = $request->headers["X-Forwarded-Proto"][0] ?? $components["scheme"] ?? null;
+        $scheme = $components["scheme"] ?? null;
+        if(isset($request->headers["X-Forwarded-Proto"][0]) && in_array("x-forwarded-proto", $this->trustedHeaders, true)) {
+            $scheme = $request->headers["X-Forwarded-Proto"][0];
+        }
+        $components["scheme"] = $scheme;
 
         if ($components === false) {
             throw new \Exception('Failed to parse RoadRunner request URI');
@@ -123,7 +149,13 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 
         $server['REQUEST_TIME'] = $this->timeInt();
         $server['REQUEST_TIME_FLOAT'] = $this->timeFloat();
-        $server['REMOTE_ADDR'] = $request->headers["X-Forwarded-For"][0] ?? $request->getRemoteAddr();
+
+        $remoteAddr = $request->getRemoteAddr();
+        if(isset($request->headers["X-Forwarded-For"][0]) && in_array("x-forwarded-for", $this->trustedHeaders, true)) {
+            $remoteAddr = $request->headers["X-Forwarded-For"][0];
+        }
+        $server['REMOTE_ADDR'] = $remoteAddr;
+
         $server['REQUEST_METHOD'] = $request->method;
         $server['SERVER_PROTOCOL'] = $request->protocol;
 

--- a/src/RoadRunnerBridge/HttpFoundationWorker.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker.php
@@ -95,6 +95,8 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 
         $components = parse_url($request->uri);
 
+        $components["scheme"] = $request->headers["X-Forwarded-Proto"][0] ?? $components["scheme"] ?? null;
+
         if ($components === false) {
             throw new \Exception('Failed to parse RoadRunner request URI');
         }
@@ -121,7 +123,7 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 
         $server['REQUEST_TIME'] = $this->timeInt();
         $server['REQUEST_TIME_FLOAT'] = $this->timeFloat();
-        $server['REMOTE_ADDR'] = $request->getRemoteAddr();
+        $server['REMOTE_ADDR'] = $request->headers["X-Forwarded-For"][0] ?? $request->getRemoteAddr();
         $server['REQUEST_METHOD'] = $request->method;
         $server['SERVER_PROTOCOL'] = $request->protocol;
 


### PR DESCRIPTION
If RR is running inside Docker and we simply pass `https` requests from proxy (basicaly proxy manages certificates) to the RR instance as `http`, the parsed `uri` scheme in this bundle will always be in this case `http` and Symfony will now use invalid schema or add 443 port when generating URLs.

Checking if `X-Forwarded-Proto` is trusted header and making it priority in `HttpFoundationWoker->configureServer()` fixes this issue. To make the rest of Symfony proxy features work we also need to set `REMOTE_ADDR` to the `X-Forwarded-For` header, also only if its trusted.

This should be a non breaking change for everyone.