### PR TITLE
Fix: migrate "MASTER_REQUEST" to "MAIN_REQUEST" for Symfony 7 compatibility

### DIFF
--- a/src/Http/MiddlewareStack.php
+++ b/src/Http/MiddlewareStack.php
@@ -55,7 +55,7 @@ final class Runner implements HttpKernelInterface
     ) {
     }
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true): Response
+    public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = true): Response
     {
         if ($this->middlewares->isEmpty()) {
             $gen = $this->handler->handle($request);

--- a/src/Reboot/OnExceptionRebootStrategy.php
+++ b/src/Reboot/OnExceptionRebootStrategy.php
@@ -33,7 +33,7 @@ class OnExceptionRebootStrategy implements KernelRebootStrategyInterface, EventS
 
     public function onException(ExceptionEvent $event): void
     {
-        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+        if ($event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
             return;
         }
 

--- a/tests/Http/KernelHandlerTest.php
+++ b/tests/Http/KernelHandlerTest.php
@@ -107,7 +107,7 @@ class KernelHandlerTest extends TestCase
         return new class($callback) extends CallableHttpKernel implements TerminableInterface {
             public $terminateCalled = false;
 
-            public function terminate(Request $request, Response $response)
+            public function terminate(Request $request, Response $response): void
             {
                 $this->terminateCalled = true;
             }

--- a/tests/Reboot/OnExceptionRebootStrategyTest.php
+++ b/tests/Reboot/OnExceptionRebootStrategyTest.php
@@ -84,7 +84,7 @@ class OnExceptionRebootStrategyTest extends TestCase
 
     private function dispatchException(\Exception $e)
     {
-        $event = new ExceptionEvent($this->prophesize(KernelInterface::class)->reveal(), new Request(), KernelInterface::MASTER_REQUEST, $e);
+        $event = new ExceptionEvent($this->prophesize(KernelInterface::class)->reveal(), new Request(), KernelInterface::MAIN_REQUEST, $e);
         $this->dispatcher->dispatch($event, KernelEvents::EXCEPTION);
     }
 }

--- a/tests/Utils/CallableHttpKernel.php
+++ b/tests/Utils/CallableHttpKernel.php
@@ -17,7 +17,7 @@ class CallableHttpKernel implements HttpKernelInterface
         $this->callable = $callable;
     }
 
-    public function handle(Request $request, int $type = self::MASTER_REQUEST, bool $catch = true): Response
+    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
     {
         return ($this->callable)($request);
     }


### PR DESCRIPTION
Fixes #132 , backwards compatible up to 5.3