### PR TITLE
Implement Generator-based response streaming

### DIFF
--- a/src/Http/StreamedResponse.php
+++ b/src/Http/StreamedResponse.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Baldinof\RoadRunnerBundle\Http;
+
+use Symfony\Component\HttpFoundation\StreamedResponse as SymfonyStreamedResponse;
+
+class StreamedResponse extends SymfonyStreamedResponse
+{
+    private \Closure $obControl;
+
+    /**
+     * @param callable|null $obControl Sets the output buffering control. Called only when sending response trough sendResponse().
+     */
+    public function __construct(?callable $callback = null, int $status = 200, array $headers = [], ?callable $obControl = null)
+    {
+        parent::__construct($callback, $status, $headers);
+
+        $this->obControl = $obControl ?? function () {
+            if (\ob_get_status()) {
+                \ob_flush();
+            }
+            \flush();
+        };
+    }
+
+    public function getGenerator(): \Generator
+    {
+        if (!isset($this->callback)) {
+            throw new \LogicException('The Response callback must be set.');
+        }
+
+        $generator = ($this->callback)();
+        if (!$generator instanceof \Generator) {
+            throw new \LogicException('The Response callback is not a valid generator.');
+        }
+
+        return $generator;
+    }
+
+    public function sendContent(): static
+    {
+        if ($this->streamed) {
+            return $this;
+        }
+
+        $this->streamed = true;
+
+        if (!isset($this->callback)) {
+            throw new \LogicException('The Response callback must be set.');
+        }
+
+        foreach ($this->getGenerator() as $chunk) {
+            echo $chunk;
+            ($this->obControl)();
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
POC of proper Response streaming.

I'm currently working on an app which uses Response streaming. It's a simple use case, where progress updates are pushed to the client.
The team uses both symfony-cli runtime and Roadrunner.

With this PR, I'd like to open a discussion on whether this is the correct approach (eg. I'm not sure this extended version of StreamedResponse fits into this project).

IMPORTANT: This will not work without appropriate change in `symfony/http-kernel`, which wraps Response callback and does not return the value (which must be a Generator instance) ([PR](https://github.com/symfony/symfony/pull/54286)).

This update changes the client API.
Before:
```php
use Symfony\Component\HttpFoundation\StreamedResponse;

$response = new StreamedResponse();
$response->setCallback(function (): void {
    echo 'Hello World';
    flush();
    sleep(2);
    echo 'Hello World';
    flush();
});
```
After:
```php
use Baldinof\RoadRunnerBundle\Http\StreamedResponse;

$response = new StreamedResponse();
$response->setCallback(function (): void {
    yield 'Hello World';
    sleep(2);
    yield 'Hello World';
});

```

___
At the moment, in my project I've added composer hook to patch files from the PR. This is not an optimal solution as it adds unnecessary maintenance overhead.