### PR TITLE
Feat: support ResetInterface for gRPC services

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -13,9 +13,11 @@ use Baldinof\RoadRunnerBundle\Http\RequestHandlerInterface;
 use Baldinof\RoadRunnerBundle\Reboot\KernelRebootStrategyInterface;
 use Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
 use Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorkerInterface;
+use Baldinof\RoadRunnerBundle\Worker\GrpcResetWorkerFinalizer;
 use Baldinof\RoadRunnerBundle\Worker\GrpcWorker as InternalGrpcWorker;
 use Baldinof\RoadRunnerBundle\Worker\HttpDependencies;
 use Baldinof\RoadRunnerBundle\Worker\HttpWorker as InternalHttpWorker;
+use Baldinof\RoadRunnerBundle\Worker\WorkerFinalizerInterface;
 use Baldinof\RoadRunnerBundle\Worker\WorkerRegistry;
 use Baldinof\RoadRunnerBundle\Worker\WorkerRegistryInterface;
 use Psr\Log\LoggerInterface;
@@ -64,6 +66,8 @@ return static function (ContainerConfigurator $container) {
 
     $services->set(WorkerRegistryInterface::class, WorkerRegistry::class)
         ->public();
+
+    $services->set(WorkerFinalizerInterface::class, GrpcResetWorkerFinalizer::class);
 
     $services->set(InternalHttpWorker::class)
         ->public() // Manually retrieved on the DIC in the Worker if the kernel has been rebooted
@@ -116,6 +120,7 @@ return static function (ContainerConfigurator $container) {
                 service(RoadRunnerWorkerInterface::class),
                 service(GrpcServiceProvider::class),
                 service(GrpcServer::class),
+                service(WorkerFinalizerInterface::class)
             ]);
 
         $services

--- a/src/Worker/GrpcResetWorkerFinalizer.php
+++ b/src/Worker/GrpcResetWorkerFinalizer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Worker;
+
+use Spiral\RoadRunner\GRPC\ServiceInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+final class GrpcResetWorkerFinalizer implements WorkerFinalizerInterface
+{
+    /**
+     * @var list<ServiceInterface>
+     */
+    private array $registeredServices = [];
+
+    public function __invoke(): void
+    {
+        foreach ($this->registeredServices as $service) {
+            if ($service instanceof ResetInterface) {
+                $service->reset();
+            }
+        }
+    }
+
+    /**
+     * @param list<ServiceInterface>  $services
+     */
+    public function setRegisteredServices(array $services): void
+    {
+        $this->registeredServices = $services;
+    }
+}

--- a/src/Worker/GrpcWorker.php
+++ b/src/Worker/GrpcWorker.php
@@ -20,7 +20,8 @@ final class GrpcWorker implements WorkerInterface
         private LoggerInterface $logger,
         private RoadRunnerWorker $roadRunnerWorker,
         private GrpcServiceProvider $grpcServiceProvider,
-        private Server $server
+        private Server $server,
+        private WorkerFinalizerInterface $workerFinalizer,
     ) {
     }
 
@@ -38,6 +39,8 @@ final class GrpcWorker implements WorkerInterface
             $this->server->registerService($interface, $service);
         }
 
-        $this->server->serve($this->roadRunnerWorker);
+        $this->workerFinalizer->setRegisteredServices($this->grpcServiceProvider->getRegisteredServices());
+
+        $this->server->serve($this->roadRunnerWorker, $this->workerFinalizer);
     }
 }

--- a/src/Worker/WorkerFinalizerInterface.php
+++ b/src/Worker/WorkerFinalizerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Worker;
+
+use Spiral\RoadRunner\GRPC\ServiceInterface;
+
+interface WorkerFinalizerInterface
+{
+    public function __invoke(): void;
+
+    /**
+     * @param list<ServiceInterface>  $services
+     */
+    public function setRegisteredServices(array $services): void;
+}


### PR DESCRIPTION
gRPC request processing with mandatory state reset of grpc-services that implements `ResetInterface` interface.

The implementation is essentially based on executing the finalizer after processing a request. An extension point as  `WorkerFinalizerInterface` is present in case there is a need to add/modify existing functionality. 