### PR TITLE
Feat: Register KvCacheAdapter as lazy service

### DIFF
--- a/src/Cache/KvCacheAdapter.php
+++ b/src/Cache/KvCacheAdapter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Cache\Adapter\Psr16Adapter;
 /**
  * @internal
  */
-final class KvCacheAdapter extends Psr16Adapter
+class KvCacheAdapter extends Psr16Adapter
 {
     public static function createConnection(#[\SensitiveParameter] string $dsn, array $options = []): self
     {

--- a/src/DependencyInjection/BaldinofRoadRunnerExtension.php
+++ b/src/DependencyInjection/BaldinofRoadRunnerExtension.php
@@ -242,7 +242,8 @@ class BaldinofRoadRunnerExtension extends Extension
                 ->setArguments(['', [ // Symfony overrides the first argument with the DSN, so we pass an empty string
                     'rpc' => $container->getDefinition(RPCInterface::class),
                     'storage' => $storage,
-                ]]);
+                ]])
+                ->setLazy(true);
         }
     }
 }


### PR DESCRIPTION
My example - Symfony Command without any cache adapter layer and `rr` dependencies. 
But while container build process it tries to autoconfigure another Commands with `CachePoolInterface` dependencies and do real connection.

The PR mark KV cache services as lazy to prevent this behaviour.
dev comment: we should remove `final` keyword from KvCacheAdapter because now it is a proxy