### PR TITLE
feat: add support for Symfony 5.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,14 +5,22 @@ on:
     - cron:  '0 0 * * *'
 jobs:
   test:
-    name: PHPUnit (PHP ${{ matrix.php-versions }}) (${{ matrix.composer }} dependencies)
-    runs-on: ${{ matrix.operating-system }}
+    name: PHPUnit (PHP ${{ matrix.php-versions }}) (SF ${{ matrix.sf-version }}) (${{ matrix.composer }} dependencies)
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
+        sf-version: ["*"]
         php-versions: ['8.1', '8.2', '8.3', '8.4']
-        composer: ["lowest", "highest"]
+        composer: [ "lowest", "highest" ]
+        include:
+          - sf-version: "5.4.*"
+            php-versions: '8.3'
+            composer: 'highest'
+          - sf-version: "6.4.*"
+            php-versions: '8.3'
+            composer: 'highest'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,11 +29,13 @@ jobs:
         with:
           php-version: '${{ matrix.php-versions }}'
           extensions: mbstring,intl,mongodb
-          tools: composer:v2
+          tools: composer:v2,flex
       - name: Install dependencies
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.composer }}
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.sf-version }}
       - name: PHPUnit
         run: composer test
 
@@ -35,7 +45,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
         php-versions: ['8.1', '8.2', '8.3', '8.4']
         composer: ["lowest", "highest"]
     steps:

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/config": "^6.0 || ^7.0",
-        "symfony/dependency-injection": "^6.0 || ^7.0",
-        "symfony/http-kernel": "^6.0 || ^7.0",
-        "symfony/yaml": "^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
         "spiral/roadrunner": "^2023.1.0 || ^2024.1.0",
         "spiral/roadrunner-worker": "^3.0.0",
         "spiral/goridge": "^4.0",
@@ -40,13 +40,13 @@
     "require-dev": {
         "symfony/var-dumper": "^6.0 || ^7.0",
         "sentry/sentry-symfony": "^4.5 || ^5.0",
-        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "nyholm/psr7": "^1.2",
         "doctrine/mongodb-odm": "^2.2",
         "blackfire/php-sdk": "^1.21",
         "doctrine/doctrine-bundle": "^2.1.1",
         "doctrine/orm": "^2.7.3",
-        "symfony/proxy-manager-bridge": "^6.0 || ^7.0",
+        "symfony/proxy-manager-bridge": "^5.4 ||^6.0 || ^7.0",
         "symfony/validator": "^6.0 || ^7.0",
         "spiral/roadrunner-metrics": "^3.0.0",
         "mikey179/vfsstream": "^1.6.8",
@@ -62,7 +62,9 @@
     "conflict": {
         "doctrine/doctrine-bundle": "<2.1.1",
         "sentry/sentry-symfony": "<4.5.0",
-        "spiral/roadrunner-metrics": "<3.0.0"
+        "spiral/roadrunner-metrics": "<3.0.0",
+        "symfony/proxy-manager-bridge": "<5.4",
+        "symfony/runtime": "<6.4"
     },
     "scripts": {
         "test": "vendor/bin/phpunit --testdox --colors=always",


### PR DESCRIPTION
This is an unusual request. Symfony 5.4 will be officially supported for [another 4 years](https://symfony.com/releases/5.4). I did check how we were using each Symfony component and I found no BC breaks. 

This PR make sure we test Symfony 6.4 high. It also allows you to install Symfony 5.4. Lowest deps are already tested so I added another item to the matrix to test 5.4 highest. 

The magic is in the flex tool. 