### PR TITLE
Feat: set runtime mode

### DIFF
--- a/src/Runtime/Runner.php
+++ b/src/Runtime/Runner.php
@@ -19,7 +19,7 @@ class Runner implements RunnerInterface
 
     public function run(): int
     {
-        $_SERVER['APP_RUNTIME_MODE'] = \sprintf('web=%d&worker=1', $this->mode == Mode::MODE_HTTP ? 1 : 0);
+        $_SERVER['APP_RUNTIME_MODE'] = \sprintf('web=%d&worker=1', $this->mode === Mode::MODE_HTTP ? 1 : 0);
         
         $this->kernel->boot();
 

--- a/src/Runtime/Runner.php
+++ b/src/Runtime/Runner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Baldinof\RoadRunnerBundle\Runtime;
 
 use Baldinof\RoadRunnerBundle\Worker\WorkerRegistryInterface;
+use Spiral\RoadRunner\Environment\Mode;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 
@@ -18,6 +19,8 @@ class Runner implements RunnerInterface
 
     public function run(): int
     {
+        $_SERVER['APP_RUNTIME_MODE'] = \sprintf('web=%d&worker=1', $this->mode == Mode::MODE_HTTP ? 1 : 0);
+        
         $this->kernel->boot();
 
         /** @var WorkerRegistryInterface $registry */


### PR DESCRIPTION
Hi,

I propose this small change to set APP_RUNTIME_MODE, similar to the way it is done in the [FrankenPHP-Runtime](https://github.com/php-runtime/frankenphp-symfony/blob/34b8c25e4b1043dec2a51dfebbc776260acf1921/src/Runner.php#L33)

With this change the DebugLoggerConfigurator will be enabled, and as a result the log-panel in the Web Profiler is not empty. (tested with Symfony 7.2)

Whil there might be more consequences that I'm no fully aware of, I believe there are no downsides, as this functionality aligns with the intended use by the Symfony developers. 

Runtime Mode Docs: https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-runtime-mode