### PR TITLE
Fix a race condition when a kernel reboot is triggered

### DIFF
--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -79,21 +79,22 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
         }
 
         if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
-            if ($this->kernel->getContainer()->has('services_resetter')) {
-                try {
+            try {
+                if ($this->kernel->getContainer()->has('services_resetter')) {
                     /** @var ResetInterface $resetter */
                     $resetter = $this->kernel->getContainer()->get('services_resetter');
                     $resetter->reset();
-                } catch (\Throwable $e) {
-                    $this->logger->error(
-                        \sprintf(
-                            'An error occurred when resetting services: %s',
-                            $e->getMessage()
-                        ),
-                        ['throwable' => $e]
-                    );
-                    throw $e;
                 }
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    \sprintf(
+                        'An error occurred when resetting services: %s',
+                        $e->getMessage()
+                    ),
+                    ['exception' => $e]
+                );
+
+                throw $e;
             }
 
             $this->kernel->reboot(null);

--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -78,29 +78,33 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
             $this->gen = null;
         }
 
-        try {
-            if ($this->kernel->getContainer()->has('services_resetter')) {
-                /** @var ResetInterface $resetter */
-                $resetter = $this->kernel->getContainer()->get('services_resetter');
-                $resetter->reset();
-            }
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                \sprintf(
-                    'An error occurred when resetting services: %s',
-                    $e->getMessage()
-                ),
-                ['exception' => $e]
-            );
-        }
-
         if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
+            try {
+                if ($this->kernel->getContainer()->has('services_resetter')) {
+                    /** @var ResetInterface $resetter */
+                    $resetter = $this->kernel->getContainer()->get('services_resetter');
+                    $resetter->reset();
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    \sprintf(
+                        'An error occurred when resetting services: %s',
+                        $e->getMessage()
+                    ),
+                    ['exception' => $e]
+                );
+            }
+
             $this->kernel->reboot(null);
             /** @var GrpcDependencies */
             $deps = $this->kernel->getContainer()->get(GrpcDependencies::class);
 
             $this->dependencies = $deps;
             $this->dependencies->getEventDispatcher()->dispatch(new WorkerKernelRebootedEvent());
+        } elseif ($this->kernel->getContainer()->has('services_resetter')) {
+            /** @var ResetInterface $resetter */
+            $resetter = $this->kernel->getContainer()->get('services_resetter');
+            $resetter->reset();
         }
 
         $this->dependencies->getKernelRebootStrategy()->clear();

--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -80,9 +80,20 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
 
         if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
             if ($this->kernel->getContainer()->has('services_resetter')) {
-                /** @var ResetInterface $resetter */
-                $resetter = $this->kernel->getContainer()->get('services_resetter');
-                $resetter->reset();
+                try {
+                    /** @var ResetInterface $resetter */
+                    $resetter = $this->kernel->getContainer()->get('services_resetter');
+                    $resetter->reset();
+                } catch (\Throwable $e) {
+                    $this->logger->error(
+                        \sprintf(
+                            'An error occurred when resetting services: %s',
+                            $e->getMessage()
+                        ),
+                        ['throwable' => $e]
+                    );
+                    throw $e;
+                }
             }
 
             $this->kernel->reboot(null);

--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -78,25 +78,23 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
             $this->gen = null;
         }
 
-        if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
-            try {
-                if ($this->kernel->getContainer()->has('services_resetter')) {
-                    /** @var ResetInterface $resetter */
-                    $resetter = $this->kernel->getContainer()->get('services_resetter');
-                    $resetter->reset();
-                }
-            } catch (\Throwable $e) {
-                $this->logger->error(
-                    \sprintf(
-                        'An error occurred when resetting services: %s',
-                        $e->getMessage()
-                    ),
-                    ['exception' => $e]
-                );
-
-                throw $e;
+        try {
+            if ($this->kernel->getContainer()->has('services_resetter')) {
+                /** @var ResetInterface $resetter */
+                $resetter = $this->kernel->getContainer()->get('services_resetter');
+                $resetter->reset();
             }
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                \sprintf(
+                    'An error occurred when resetting services: %s',
+                    $e->getMessage()
+                ),
+                ['exception' => $e]
+            );
+        }
 
+        if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
             $this->kernel->reboot(null);
             /** @var GrpcDependencies */
             $deps = $this->kernel->getContainer()->get(GrpcDependencies::class);

--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -79,16 +79,18 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
         }
 
         if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
+            if ($this->kernel->getContainer()->has('services_resetter')) {
+                /** @var ResetInterface $resetter */
+                $resetter = $this->kernel->getContainer()->get('services_resetter');
+                $resetter->reset();
+            }
+
             $this->kernel->reboot(null);
             /** @var GrpcDependencies */
             $deps = $this->kernel->getContainer()->get(GrpcDependencies::class);
 
             $this->dependencies = $deps;
             $this->dependencies->getEventDispatcher()->dispatch(new WorkerKernelRebootedEvent());
-        } elseif ($this->kernel->getContainer()->has('services_resetter')) {
-            /** @var ResetInterface $resetter */
-            $resetter = $this->kernel->getContainer()->get('services_resetter');
-            $resetter->reset();
         }
 
         $this->dependencies->getKernelRebootStrategy()->clear();

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -146,9 +146,20 @@ final class HttpWorker implements WorkerInterface
             } finally {
                 if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
                     if ($this->kernel->getContainer()->has('services_resetter')) {
-                        /** @var ResetInterface $resetter */
-                        $resetter = $this->kernel->getContainer()->get('services_resetter');
-                        $resetter->reset();
+                        try {
+                            /** @var ResetInterface $resetter */
+                            $resetter = $this->kernel->getContainer()->get('services_resetter');
+                            $resetter->reset();
+                        } catch (\Throwable $e) {
+                            $this->logger->error(
+                                \sprintf(
+                                    'An error occurred when resetting services: %s',
+                                    $e->getMessage()
+                                ),
+                                ['throwable' => $e]
+                            );
+                            throw $e;
+                        }
                     }
 
                     $this->kernel->reboot(null);

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\RebootableInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 use function Baldinof\RoadRunnerBundle\consumes;
 
@@ -144,6 +145,12 @@ final class HttpWorker implements WorkerInterface
                 break;
             } finally {
                 if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
+                    if ($this->kernel->getContainer()->has('services_resetter')) {
+                        /** @var ResetInterface $resetter */
+                        $resetter = $this->kernel->getContainer()->get('services_resetter');
+                        $resetter->reset();
+                    }
+
                     $this->kernel->reboot(null);
                     /** @var HttpDependencies */
                     $deps = $this->kernel->getContainer()->get(HttpDependencies::class);

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -159,8 +159,6 @@ final class HttpWorker implements WorkerInterface
                             ),
                             ['exception' => $e]
                         );
-
-                        throw $e;
                     }
 
                     $this->kernel->reboot(null);

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -145,21 +145,22 @@ final class HttpWorker implements WorkerInterface
                 break;
             } finally {
                 if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
-                    if ($this->kernel->getContainer()->has('services_resetter')) {
-                        try {
+                    try {
+                        if ($this->kernel->getContainer()->has('services_resetter')) {
                             /** @var ResetInterface $resetter */
                             $resetter = $this->kernel->getContainer()->get('services_resetter');
                             $resetter->reset();
-                        } catch (\Throwable $e) {
-                            $this->logger->error(
-                                \sprintf(
-                                    'An error occurred when resetting services: %s',
-                                    $e->getMessage()
-                                ),
-                                ['throwable' => $e]
-                            );
-                            throw $e;
                         }
+                    } catch (\Throwable $e) {
+                        $this->logger->error(
+                            \sprintf(
+                                'An error occurred when resetting services: %s',
+                                $e->getMessage()
+                            ),
+                            ['exception' => $e]
+                        );
+
+                        throw $e;
                     }
 
                     $this->kernel->reboot(null);

--- a/tests/Worker/GrpcWorkerTest.php
+++ b/tests/Worker/GrpcWorkerTest.php
@@ -237,4 +237,37 @@ class GrpcWorkerTest extends TestCase
         $this->kernel->reboot(null)->shouldHaveBeenCalled();
         $this->assertTrue($rebootedEventFired);
     }
+
+    public function test_it_resets_services_before_reboot(): void
+    {
+        $this->responder = function () use (&$terminated) {
+            yield 'hello';
+
+            $terminated = true;
+        };
+
+        $this->roadrunnerWorker->respond(Argument::any()); // Allow respond() calls
+
+        $this->requests->push(new Payload('', Json::encode([
+            'service' => FakeGrpcService::NAME,
+            'method' => 'fake',
+            'context' => [],
+        ])));
+
+        $resetter = $this->prophesize(\Symfony\Contracts\Service\ResetInterface::class);
+        $resetter->reset()->shouldBeCalledOnce();
+        $this->container->set('services_resetter', $resetter->reveal());
+
+        self::$rebootStrategyReturns = true;
+
+        $rebootedEventFired = false;
+        $this->eventDispatcher->addListener(WorkerKernelRebootedEvent::class, function () use (&$rebootedEventFired) {
+            $rebootedEventFired = true;
+        });
+
+        $this->worker->start();
+
+        $this->kernel->reboot(null)->shouldHaveBeenCalled();
+        $this->assertTrue($rebootedEventFired);
+    }
 }

--- a/tests/Worker/HttpWorkerTest.php
+++ b/tests/Worker/HttpWorkerTest.php
@@ -268,7 +268,7 @@ class HttpWorkerTest extends TestCase
         $this->assertTrue($rebootedEventFired);
     }
 
-    public function test_it_resets_services_after_reboot(): void
+    public function test_it_resets_services_before_reboot(): void
     {
         $this->responder = function () use (&$terminated) {
             yield new Response('hello', 200, []);

--- a/tests/Worker/HttpWorkerTest.php
+++ b/tests/Worker/HttpWorkerTest.php
@@ -267,4 +267,25 @@ class HttpWorkerTest extends TestCase
         $this->kernel->reboot(null)->shouldHaveBeenCalled();
         $this->assertTrue($rebootedEventFired);
     }
+
+    public function test_it_resets_services_after_reboot(): void
+    {
+        $this->responder = function () use (&$terminated) {
+            yield new Response('hello', 200, []);
+
+            $terminated = true;
+        };
+
+        $this->httpFoundationWorker->respond(Argument::any()); // Allow respond() calls
+
+        $this->requests->push(Request::create('http://example.org/'));
+
+        $resetter = $this->prophesize(\Symfony\Contracts\Service\ResetInterface::class);
+        $resetter->reset()->shouldBeCalledOnce();
+        $this->container->set('services_resetter', $resetter->reveal());
+
+        self::$rebootStrategyReturns = true;
+        $this->worker->start();
+        $this->kernel->reboot(null)->shouldHaveBeenCalled();
+    }
 }


### PR DESCRIPTION
A race condition is observed when a kernel reboot is triggered leading for some requests to not experience a service reset.

This leads for example to Client B having session data of Client A

### How to reproduce

1. Checkout https://github.com/mikael-titinovskii/sf-rr-bug-demo  on branch main
2. run chmod +x test.sh
3. open 3 terminal windows
4. on terminal 1 run rr serve
5. on terminal 2 run test.sh 1
6. on terminal 3 run test.sh 2

### What to look for 

![ezgif-36328d87dc3d49](https://github.com/user-attachments/assets/0ae1a2c4-bb75-4d2f-a8e7-326f4d602619)

terminal 3 window will indicate that it has session from terminal 2
a json will appear, for example
```
{"session_id":"e2qq7ggu9hlmme96c93kir5dhk","pid":84487,"cr":"2","cs":"1","match":"no ********"} 
```
from time to time cr - client from request will not match cs - client from session 

another experiment you can comment out the block in TestController 
```
        // reset the session
        if (rand(0,10) === 10){
            $session->clear();
            $session->invalidate();
            $session->getFlashBag()->clear();
            $session->migrate(true);
        }

``` 

now the session change is permanent for client 2 

### Other observations: 
- adding more "clients" will make the event less frequent
- increasing the number of workers, for ex 20, will make the event less frequent
- on  > 0.2 rps  the bug is barely noticeable 

### Issue source

i notice that \Symfony\Component\HttpKernel\Kernel::shutdown flips resetServices to false 

\Symfony\Component\HttpKernel\Kernel::handle sets resetServices to true then has that var is overturned to false 

### The fix proposal: 

I've added this fix to reset the services before a reboot

to test the effects, switch to branch ``` with-fix ``` and run composer install and run the procedure again

