### PR TITLE
feat: xdebug integration for roadrunner workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Depending on installed bundle & your configuration, this bundles add some integr
 - **Doctrine Mongo Bundle**: clear opened managers after each requests (if [`DoctrineMongoDBBundle`](https://github.com/doctrine/DoctrineMongoDBBundle) is installed)
 - **Doctrine ORM Bundle**: clear opened managers and check connection is still usable after each requests (if [`DoctrineBundle`](https://github.com/doctrine/DoctrineBundle) is installed)
 - **Blackfire**: enable the probe when a profile is requested (if the [`blackfire`](https://blackfire.io/) extension is installed)
+- **Xdebug**: allow Xdebug in trigger mode (if the [`xdebug`](https://xdebug.org/) extension is installed)
 
 Even if it is not recommended, you can disable default integrations:
 

--- a/src/DependencyInjection/BaldinofRoadRunnerExtension.php
+++ b/src/DependencyInjection/BaldinofRoadRunnerExtension.php
@@ -14,6 +14,8 @@ use Baldinof\RoadRunnerBundle\Integration\Sentry\SentryListener;
 use Baldinof\RoadRunnerBundle\Integration\Sentry\SentryMiddleware;
 use Baldinof\RoadRunnerBundle\Integration\Sentry\SentryTracingRequestListenerDecorator;
 use Baldinof\RoadRunnerBundle\Integration\Symfony\ConfigureVarDumperListener;
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugProxy;
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugTriggerMiddleware;
 use Baldinof\RoadRunnerBundle\Reboot\AlwaysRebootStrategy;
 use Baldinof\RoadRunnerBundle\Reboot\ChainRebootStrategy;
 use Baldinof\RoadRunnerBundle\Reboot\KernelRebootStrategyInterface;
@@ -148,6 +150,21 @@ class BaldinofRoadRunnerExtension extends Extension
             return;
         }
 
+        // ext-xdebug might not be there when building the container, so let's not test for the extension to be loaded.
+        if ($container->getParameter('kernel.debug')) {
+            $container
+                ->register(XdebugProxy::class)
+                ->setAutoconfigured(true);
+            $container
+                ->register(XdebugTriggerMiddleware::class)
+                ->addArgument(new Reference(XdebugProxy::class))
+                ->setAutoconfigured(true);
+
+            // Xdebug should always be the first middleware/interceptor to be executed
+            $beforeMiddlewares[] = XdebugTriggerMiddleware::class;
+            $beforeInterceptors[] = XdebugTriggerMiddleware::class;
+        }
+
         /** @var array */
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -198,6 +215,7 @@ class BaldinofRoadRunnerExtension extends Extension
             $beforeMiddlewares[] = DoctrineORMMiddleware::class;
             $beforeInterceptors[] = DoctrineORMMiddleware::class;
         }
+
         $container->setParameter('baldinof_road_runner.middlewares.default', ['before' => $beforeMiddlewares, 'after' => $lastMiddlewares]);
         if (interface_exists(ServiceInterface::class)) {
             $container->setParameter('baldinof_road_runner.interceptors.default', ['before' => $beforeInterceptors, 'after' => $afterInterceptors]);

--- a/src/Integration/Xdebug/XdebugProxy.php
+++ b/src/Integration/Xdebug/XdebugProxy.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Integration\Xdebug;
+
+/**
+ * @internal
+ *
+ * This class is a proxy to the Xdebug extension.
+ * It allow to mock/stub global php functions during tests.
+ * It also remove the requirement to install the Xdebug extension to run tests.
+ */
+class XdebugProxy
+{
+    public function isExtensionLoaded(): bool
+    {
+        return \extension_loaded('xdebug');
+    }
+
+    /**
+     * @return 'yes'|'no'|'trigger'
+     */
+    public function startWithRequest(): string
+    {
+        $config = \ini_get('xdebug.start_with_request');
+        if (\in_array($config, ['yes', 'no', 'trigger'], true)) {
+            return $config;
+        }
+        if ($this->hasMode('profile')) {
+            return 'yes';
+        }
+        if ($this->hasMode('debug') || $this->hasMode('trace')) {
+            return 'trigger';
+        }
+
+        return 'no';
+    }
+
+    /**
+     * @return ?non-empty-string
+     */
+    public function triggerValue(): ?string
+    {
+        return \ini_get('xdebug.trigger_value') ?: null;
+    }
+
+    public function hasMode(string $mode): bool
+    {
+        return \in_array($mode, xdebug_info('mode'), true);
+    }
+
+    public function notify(mixed $data): bool
+    {
+        return xdebug_notify($data);
+    }
+
+    public function connectToClient(): bool
+    {
+        return xdebug_connect_to_client();
+    }
+}

--- a/src/Integration/Xdebug/XdebugTriggerMiddleware.php
+++ b/src/Integration/Xdebug/XdebugTriggerMiddleware.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\Integration\Xdebug;
+
+use Baldinof\RoadRunnerBundle\Grpc\InterceptorInterface;
+use Baldinof\RoadRunnerBundle\Http\MiddlewareInterface;
+use Baldinof\RoadRunnerBundle\RoadRunnerBridge\GrpcRequest;
+use Baldinof\RoadRunnerBundle\RoadRunnerBridge\GrpcRequestInvokerInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class XdebugTriggerMiddleware implements MiddlewareInterface, InterceptorInterface
+{
+    public function __construct(
+        private readonly XdebugProxy $xdebug,
+    ) {
+    }
+
+    public function process(HttpRequest $request, HttpKernelInterface $next): \Iterator
+    {
+        $connected = $this->preRequest($request);
+        try {
+            yield $next->handle($request);
+        } finally {
+            if ($connected) {
+                $this->postResponse();
+            }
+        }
+    }
+
+    public function intercept(GrpcRequest $invocation, GrpcRequestInvokerInterface $next): \Iterator
+    {
+        $connected = $this->preRequest($invocation);
+        try {
+            yield $next->invoke($invocation);
+        } finally {
+            if ($connected) {
+                $this->postResponse();
+            }
+        }
+    }
+
+    private function preRequest(HttpRequest|GrpcRequest $request): bool
+    {
+        if (!$this->xdebug->isExtensionLoaded()) {
+            return false;
+        }
+        $shouldTriggerXdebug = $this->shouldStartWithRequest() ?? $this->hasTrigger($request);
+        if (!$shouldTriggerXdebug) {
+            return false;
+        }
+        $this->xdebug->notify('rr-pre-request');
+        $this->xdebug->connectToClient();
+
+        return true;
+    }
+
+    private function postResponse(): void
+    {
+        $this->xdebug->notify('rr-post-response');
+    }
+
+    private function shouldStartWithRequest(): ?bool
+    {
+        return match ($this->xdebug->startWithRequest()) {
+            'yes' => true,
+            'no' => false,
+            'trigger' => null,
+        };
+    }
+
+    private function hasTrigger(HttpRequest|GrpcRequest $request): bool
+    {
+        return match (true) {
+            $request instanceof HttpRequest => $this->hasHttpTrigger($request),
+            $request instanceof GrpcRequest => $this->hasGrpcTrigger($request),
+        };
+    }
+
+    private function hasHttpTrigger(HttpRequest $request): bool
+    {
+        // Trigger behavior is tricky
+        // See https://xdebug.org/docs/step_debug#start_with_request
+        if ($this->hasNamedTrigger($request, 'XDEBUG_TRIGGER')) {
+            return true;
+        }
+        if (($this->hasNamedTrigger($request, 'XDEBUG_SESSION') || $this->hasNamedTrigger($request, 'XDEBUG_SESSION_START')) && $this->xdebug->hasMode('debug')) {
+            return true;
+        }
+        if ($this->hasNamedTrigger($request, 'XDEBUG_PROFILE') && $this->xdebug->hasMode('profile')) {
+            return true;
+        }
+        if ($this->hasNamedTrigger($request, 'XDEBUG_TRACE') && $this->xdebug->hasMode('trace')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function hasNamedTrigger(HttpRequest $request, string $name): bool
+    {
+        // Trigger behavior is tricky
+        // See https://xdebug.org/docs/step_debug#start_with_request
+        $triggerValue = $this->xdebug->triggerValue();
+        foreach ([
+            $request->query,
+            $request->request,
+            $request->cookies,
+        ] as $inputBag) {
+            if (empty($triggerValue) ? $inputBag->has($name) : $triggerValue === $inputBag->get($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasGrpcTrigger(GrpcRequest $request): bool
+    {
+        // There is no standard for gRPC trigger, so we can make one
+        $triggerValue = $this->xdebug->triggerValue();
+        $context = $request->getContext();
+        if ($trigger = $context->getValue('xdebug-trigger')) {
+            if (\is_array($trigger)) {
+                $trigger = reset($trigger);
+            }
+
+            return empty($triggerValue) || $triggerValue === $trigger;
+        }
+
+        return false;
+    }
+}

--- a/tests/BaldinofRoadRunnerBundleTest.php
+++ b/tests/BaldinofRoadRunnerBundleTest.php
@@ -10,6 +10,8 @@ use Baldinof\RoadRunnerBundle\EventListener\DeclareMetricsListener;
 use Baldinof\RoadRunnerBundle\Integration\Doctrine\DoctrineORMMiddleware;
 use Baldinof\RoadRunnerBundle\Integration\Sentry\SentryMiddleware;
 use Baldinof\RoadRunnerBundle\Integration\Sentry\SentryTracingRequestListenerDecorator;
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugProxy;
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugTriggerMiddleware;
 use Baldinof\RoadRunnerBundle\Reboot\AlwaysRebootStrategy;
 use Baldinof\RoadRunnerBundle\Reboot\ChainRebootStrategy;
 use Baldinof\RoadRunnerBundle\Reboot\KernelRebootStrategyInterface;
@@ -165,6 +167,34 @@ class BaldinofRoadRunnerBundleTest extends TestCase
         $this->assertTrue($c->has(DoctrineORMMiddleware::class));
     }
 
+    public function test_it_loads_xdebug_middleware()
+    {
+        $k = $this->getKernel();
+
+        $k->boot();
+        $c = $k->getContainer()->get('test.service_container');
+
+        $this->assertTrue($c->has(XdebugProxy::class));
+        $this->assertTrue($c->has(XdebugTriggerMiddleware::class));
+
+        // Ensure it's always the first middleware to be called
+        $middlewares = $k->getContainer()->getParameter('baldinof_road_runner.middlewares.default');
+        $this->assertEquals(XdebugTriggerMiddleware::class, $middlewares['before'][0]);
+        $interceptors = $k->getContainer()->getParameter('baldinof_road_runner.interceptors.default');
+        $this->assertEquals(XdebugTriggerMiddleware::class, $interceptors['before'][0]);
+    }
+
+    public function test_it_skips_xdebug_middleware()
+    {
+        $k = $this->getKernel(debug: false);
+
+        $k->boot();
+        $c = $k->getContainer()->get('test.service_container');
+
+        $this->assertFalse($c->has(XdebugProxy::class));
+        $this->assertFalse($c->has(XdebugTriggerMiddleware::class));
+    }
+
     public function test_it_supports_single_strategy()
     {
         $k = $this->getKernel([
@@ -238,9 +268,9 @@ class BaldinofRoadRunnerBundleTest extends TestCase
     /**
      * @param BundleInterface[] $extraBundles
      */
-    public function getKernel(array $config = [], array $extraBundles = []): KernelInterface
+    public function getKernel(array $config = [], array $extraBundles = [], bool $debug = true): KernelInterface
     {
-        return new class('test', true, $config, $extraBundles) extends Kernel {
+        return new class('test', $debug, $config, $extraBundles) extends Kernel {
             use MicroKernelTrait;
 
             private $config;

--- a/tests/Integration/Xdebug/XdebugTriggerMiddlewareTest.php
+++ b/tests/Integration/Xdebug/XdebugTriggerMiddlewareTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Baldinof\RoadRunnerBundle\Integration\Xdebug;
+
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugProxy;
+use Baldinof\RoadRunnerBundle\Integration\Xdebug\XdebugTriggerMiddleware;
+use Baldinof\RoadRunnerBundle\RoadRunnerBridge\GrpcRequest;
+use Baldinof\RoadRunnerBundle\RoadRunnerBridge\GrpcRequestInvokerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\GRPC\Context;
+use Spiral\RoadRunner\GRPC\Method;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Tests\Baldinof\RoadRunnerBundle\Grpc\FakeGrpcService;
+
+use function Baldinof\RoadRunnerBundle\consumes;
+
+class XdebugTriggerMiddlewareTest extends TestCase
+{
+    private MockObject&XdebugProxy $xdebug;
+    private MockObject&HttpKernelInterface $nextMiddleware;
+    private MockObject&GrpcRequestInvokerInterface $nextInterceptor;
+    private XdebugTriggerMiddleware $middleware;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->xdebug = $this->createMock(XdebugProxy::class);
+        $this->middleware = new XdebugTriggerMiddleware($this->xdebug);
+
+        $this->nextMiddleware = $this->createMock(HttpKernelInterface::class);
+        $this->nextInterceptor = $this->createMock(GrpcRequestInvokerInterface::class);
+    }
+
+    public function testMiddlewareDoesNothingWhenXdebugExtensionIsNotLoaded(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(false);
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process(new HttpRequest(), $this->nextMiddleware));
+    }
+
+    public function testInterceptorDoesNothingWhenXdebugExtensionIsNotLoaded(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(false);
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextIteratorCalled();
+        consumes($this->middleware->intercept($this->grpcRequest(), $this->nextInterceptor));
+    }
+
+    public function testMiddlewareDoesNothingWhenXdebugStartWithRequestIsNo(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('no');
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process(new HttpRequest(), $this->nextMiddleware));
+    }
+
+    public function testInterceptorDoesNothingWhenXdebugStartWithRequestIsNo(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('no');
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextIteratorCalled();
+        consumes($this->middleware->intercept($this->grpcRequest(), $this->nextInterceptor));
+    }
+
+    public function testMiddlewareTriggersWhenXdebugStartWithRequestIsYes(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('yes');
+        $this->xdebug->expects($this->exactly(2))->method('notify');
+        $this->xdebug->expects($this->once())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process(new HttpRequest(), $this->nextMiddleware));
+    }
+
+    public function testInterceptorTriggersWhenXdebugStartWithRequestIsYes(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('yes');
+        $this->xdebug->expects($this->exactly(2))->method('notify');
+        $this->xdebug->expects($this->once())->method('connectToClient');
+        $this->expectsNextIteratorCalled();
+        consumes($this->middleware->intercept($this->grpcRequest(), $this->nextInterceptor));
+    }
+
+    public function testMiddlewareDoesNothingWhenXdebugStartWithRequestIsTriggerWithNoTrigger(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('trigger');
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process(new HttpRequest(), $this->nextMiddleware));
+    }
+
+    public function testInterceptorDoesNothingWhenXdebugStartWithRequestIsTriggerWithNoTrigger(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('trigger');
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextIteratorCalled();
+        consumes($this->middleware->intercept($this->grpcRequest(), $this->nextInterceptor));
+    }
+
+    /**
+     * @dataProvider provideRequestsWithTrigger
+     */
+    public function testMiddlewareTriggersWhenXdebugStartWithRequestITriggerWithTrigger(HttpRequest $request, bool $hasTriggerValue, ?string $specificMode): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('trigger');
+        $this->xdebug->method('triggerValue')->willReturn($hasTriggerValue ? 'rr-debug' : null);
+        if ($specificMode) {
+            $this->xdebug->method('hasMode')->with($specificMode)->willReturn(true);
+        } else {
+            $this->xdebug->expects($this->never())->method('hasMode');
+        }
+        $this->xdebug->expects($this->exactly(2))->method('notify');
+        $this->xdebug->expects($this->once())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process($request, $this->nextMiddleware));
+    }
+
+    /**
+     * @dataProvider provideRequestsWithTrigger
+     */
+    public function testMiddlewareTriggersWhenXdebugStartWithRequestITriggerWithWrongTrigger(HttpRequest $request, bool $hasTriggerValue, ?string $specificMode): void
+    {
+        if (false === $hasTriggerValue && null === $specificMode) {
+            // This case is not to be tested with this test.
+            // Make one assertion, and return to skip it with no warning.
+            // (It's better than duplicating the provider)
+            $this->assertTrue(true);
+
+            return;
+        }
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('trigger');
+        $this->xdebug->method('triggerValue')->willReturn($hasTriggerValue ? 'rr-is-awesome' : null);
+        if ($specificMode) {
+            $this->xdebug->method('hasMode')->with($specificMode)->willReturn(false);
+        } else {
+            $this->xdebug->expects($this->never())->method('hasMode');
+        }
+        $this->xdebug->expects($this->never())->method('notify');
+        $this->xdebug->expects($this->never())->method('connectToClient');
+        $this->expectsNextMiddlewareCalled();
+        consumes($this->middleware->process($request, $this->nextMiddleware));
+    }
+
+    public static function provideRequestsWithTrigger(): \Iterator
+    {
+        yield 'XDEBUG_TRIGGER (any value)' => [self::httpRequest('XDEBUG_TRIGGER'), false, null];
+        yield 'XDEBUG_TRIGGER (specific value)' => [self::httpRequest('XDEBUG_TRIGGER', 'rr-debug'), true, null];
+        yield 'XDEBUG_SESSION (any value)' => [self::httpRequest('XDEBUG_SESSION'), false, 'debug'];
+        yield 'XDEBUG_SESSION (specific value)' => [self::httpRequest('XDEBUG_SESSION', 'rr-debug'), true, 'debug'];
+        yield 'XDEBUG_SESSION_START (any value)' => [self::httpRequest('XDEBUG_SESSION_START'), false, 'debug'];
+        yield 'XDEBUG_SESSION_START (specific value)' => [self::httpRequest('XDEBUG_SESSION_START', 'rr-debug'), true, 'debug'];
+        yield 'XDEBUG_PROFILE (any value)' => [self::httpRequest('XDEBUG_PROFILE'), false, 'profile'];
+        yield 'XDEBUG_PROFILE (specific value)' => [self::httpRequest('XDEBUG_PROFILE', 'rr-debug'), true, 'profile'];
+        yield 'XDEBUG_TRACE (any value)' => [self::httpRequest('XDEBUG_TRACE'), false, 'trace'];
+        yield 'XDEBUG_TRACE (specific value)' => [self::httpRequest('XDEBUG_TRACE', 'rr-debug'), true, 'trace'];
+    }
+
+    public function testInterceptorTriggersWhenXdebugStartWithRequestIsTriggerWithTrigger(): void
+    {
+        $this->xdebug->method('isExtensionLoaded')->willReturn(true);
+        $this->xdebug->method('startWithRequest')->willReturn('yes');
+        $this->xdebug->expects($this->exactly(2))->method('notify');
+        $this->xdebug->expects($this->once())->method('connectToClient');
+        $this->expectsNextIteratorCalled();
+        consumes($this->middleware->intercept($this->grpcRequest(), $this->nextInterceptor));
+    }
+
+    private function expectsNextMiddlewareCalled(?HttpResponse $response = null): void
+    {
+        $this->nextMiddleware->expects($this->once())->method('handle')->willReturn($response ?? new HttpResponse());
+    }
+
+    private function expectsNextIteratorCalled(?string $response = null): void
+    {
+        $this->nextInterceptor->expects($this->once())->method('invoke')->willReturn($response ?? '');
+    }
+
+    private static function httpRequest(string $trigger, ?string $value = null): HttpRequest
+    {
+        // Randomize query, request and cookies to test all cases
+        return match (random_int(0, 2)) {
+            default => new HttpRequest(query: [$trigger => $value ?? '1']),
+            1 => new HttpRequest(request: [$trigger => $value ?? '1']),
+            2 => new HttpRequest(cookies: [$trigger => $value ?? '1']),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private static function grpcRequest(array $context = []): GrpcRequest
+    {
+        return new GrpcRequest(
+            new FakeGrpcService(),
+            Method::parse((new \ReflectionClass(FakeGrpcService::class))->getMethod('fake')),
+            new Context($context),
+            ''
+        );
+    }
+}


### PR DESCRIPTION
This PR adds optional Xdebug support when running the app under RoadRunner.

RoadRunner uses long-lived worker processes, which makes standard per-request Xdebug debugging unreliable. 

The changes ensure an Xdebug session can be started/handled correctly inside the worker so breakpoints and step debugging work as expected during development, even with "on-demand" triggers which requires a re-evaluation of the client connection at each request.