### PR TITLE
Supports streamed and file responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "spiral/roadrunner-worker": "^3.0.0",
         "spiral/goridge": "^4.0",
         "psr/log": "^2.0 || ^3.0",
-        "spiral/roadrunner-http": "^3.0"
+        "spiral/roadrunner-http": "^4.0"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation",

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,10 @@ use Spiral\RoadRunner\Metrics\Metrics;
 use Spiral\RoadRunner\Metrics\MetricsInterface;
 use Spiral\RoadRunner\Worker as RoadRunnerWorker;
 use Spiral\RoadRunner\WorkerInterface as RoadRunnerWorkerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\EventStreamResponse;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 return static function (ContainerConfigurator $container) {
@@ -62,8 +66,42 @@ return static function (ContainerConfigurator $container) {
         ->args([service(RPCInterface::class)]);
 
     // Bundle services
+    $container->parameters()->set('baldinof_road_runner.http_foundation_streamed_responder.chunk_size', 1024 * 16); // 16 Kb by default for streamed responses
+
+    $services->set('baldinof_road_runner.http_foundation_streamed_responder', HttpFoundationWorker\ChunkedResponder::class)
+        ->args([
+            [StreamedResponse::class, StreamedJsonResponse::class],
+            param('baldinof_road_runner.http_foundation_streamed_responder.chunk_size'),
+        ])
+        ->tag('baldinof_road_runner.http_foundation_responder');
+
+    $services->set('baldinof_road_runner.http_foundation_event_streamed_responder', HttpFoundationWorker\ChunkedResponder::class)
+        ->args([
+            [EventStreamResponse::class],
+            1,
+        ])
+        ->tag('baldinof_road_runner.http_foundation_responder');
+
+    $services->set('baldinof_road_runner.http_foundation_binary_file_responder', HttpFoundationWorker\ChunkedResponder::class)
+        ->args([
+            [BinaryFileResponse::class],
+            1,
+        ])
+        ->tag('baldinof_road_runner.http_foundation_responder');
+
+    $services->set('baldinof_road_runner.http_foundation_fallback_responder', HttpFoundationWorker\BufferedResponder::class)
+        ->tag('baldinof_road_runner.http_foundation_responder', ['priority' => -1024]);
+
+    $services->set(HttpFoundationWorker\HttpFoundationResponder::class, HttpFoundationWorker\ChainResponder::class)
+        ->args([
+            tagged_iterator('baldinof_road_runner.http_foundation_responder'),
+        ]);
+
     $services->set(HttpFoundationWorkerInterface::class, HttpFoundationWorker::class)
-        ->args([service(HttpWorkerInterface::class)]);
+        ->args([
+            service(HttpWorkerInterface::class),
+            service(HttpFoundationWorker\HttpFoundationResponder::class),
+        ]);
 
     $services->set(WorkerRegistryInterface::class, WorkerRegistry::class)
         ->public();

--- a/config/services.php
+++ b/config/services.php
@@ -70,17 +70,28 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('baldinof_road_runner.http_foundation_streamed_responder', HttpFoundationWorker\ChunkedResponder::class)
         ->args([
-            [StreamedResponse::class, StreamedJsonResponse::class],
+            [StreamedResponse::class],
             param('baldinof_road_runner.http_foundation_streamed_responder.chunk_size'),
         ])
         ->tag('baldinof_road_runner.http_foundation_responder');
 
-    $services->set('baldinof_road_runner.http_foundation_event_streamed_responder', HttpFoundationWorker\ChunkedResponder::class)
-        ->args([
-            [EventStreamResponse::class],
-            1,
-        ])
-        ->tag('baldinof_road_runner.http_foundation_responder');
+    if (class_exists(StreamedJsonResponse::class)) {
+        $services->set('baldinof_road_runner.http_foundation_streamed_json_responder', HttpFoundationWorker\ChunkedResponder::class)
+            ->args([
+                [StreamedJsonResponse::class],
+                param('baldinof_road_runner.http_foundation_streamed_responder.chunk_size'),
+            ])
+            ->tag('baldinof_road_runner.http_foundation_responder');
+    }
+
+    if (class_exists(EventStreamResponse::class)) {
+        $services->set('baldinof_road_runner.http_foundation_event_streamed_responder', HttpFoundationWorker\ChunkedResponder::class)
+            ->args([
+                [EventStreamResponse::class],
+                1,
+            ])
+            ->tag('baldinof_road_runner.http_foundation_responder');
+    }
 
     $services->set('baldinof_road_runner.http_foundation_binary_file_responder', HttpFoundationWorker\ChunkedResponder::class)
         ->args([

--- a/src/RoadRunnerBridge/HttpFoundationWorker.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker.php
@@ -35,15 +35,15 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
         return $this->toSymfonyRequest($rrRequest);
     }
 
-    public function respond(SymfonyResponse $symfonyResponse): void
+    public function respond(SymfonyResponse $response): void
     {
-        if ($symfonyResponse instanceof BinaryFileResponse && !$symfonyResponse->headers->has('Content-Range')) {
-            $content = file_get_contents($symfonyResponse->getFile()->getPathname());
+        if ($response instanceof BinaryFileResponse && !$response->headers->has('Content-Range')) {
+            $content = file_get_contents($response->getFile()->getPathname());
             if ($content === false) {
-                throw new \RuntimeException(\sprintf("Cannot read file '%s'", $symfonyResponse->getFile()->getPathname())); // TODO: custom error
+                throw new \RuntimeException(\sprintf("Cannot read file '%s'", $response->getFile()->getPathname())); // TODO: custom error
             }
         } else {
-            if ($symfonyResponse instanceof StreamedResponse || $symfonyResponse instanceof BinaryFileResponse) {
+            if ($response instanceof StreamedResponse || $response instanceof BinaryFileResponse) {
                 $content = '';
                 ob_start(function ($buffer) use (&$content) {
                     $content .= $buffer;
@@ -51,16 +51,16 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
                     return '';
                 });
 
-                $symfonyResponse->sendContent();
+                $response->sendContent();
                 ob_end_clean();
             } else {
-                $content = (string) $symfonyResponse->getContent();
+                $content = (string) $response->getContent();
             }
         }
 
-        $headers = $this->stringifyHeaders($symfonyResponse->headers->all());
+        $headers = $this->stringifyHeaders($response->headers->all());
 
-        $this->httpWorker->respond($symfonyResponse->getStatusCode(), $content, $headers);
+        $this->httpWorker->respond($response->getStatusCode(), $content, $headers);
     }
 
     public function getWorker(): WorkerInterface

--- a/src/RoadRunnerBridge/HttpFoundationWorker.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge;
 
+use Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker\HttpFoundationResponder;
 use Spiral\RoadRunner\Http\HttpWorkerInterface;
 use Spiral\RoadRunner\Http\Request as RoadRunnerRequest;
 use Spiral\RoadRunner\WorkerInterface;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 {
     private HttpWorkerInterface $httpWorker;
+    private HttpFoundationResponder $responder;
     private array $originalServer;
 
-    public function __construct(HttpWorkerInterface $httpWorker)
+    public function __construct(HttpWorkerInterface $httpWorker, HttpFoundationResponder $responder)
     {
         $this->httpWorker = $httpWorker;
+        $this->responder = $responder;
         $this->originalServer = $_SERVER;
     }
 
@@ -37,30 +38,11 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
 
     public function respond(SymfonyResponse $response): void
     {
-        if ($response instanceof BinaryFileResponse && !$response->headers->has('Content-Range')) {
-            $content = file_get_contents($response->getFile()->getPathname());
-            if ($content === false) {
-                throw new \RuntimeException(\sprintf("Cannot read file '%s'", $response->getFile()->getPathname())); // TODO: custom error
-            }
-        } else {
-            if ($response instanceof StreamedResponse || $response instanceof BinaryFileResponse) {
-                $content = '';
-                ob_start(function ($buffer) use (&$content) {
-                    $content .= $buffer;
-
-                    return '';
-                });
-
-                $response->sendContent();
-                ob_end_clean();
-            } else {
-                $content = (string) $response->getContent();
-            }
+        if (!$this->responder->supports($response)) {
+            throw new \RuntimeException('Unsupported response.');
         }
 
-        $headers = $this->stringifyHeaders($response->headers->all());
-
-        $this->httpWorker->respond($response->getStatusCode(), $content, $headers);
+        $this->responder->respond($this->httpWorker, $response);
     }
 
     public function getWorker(): WorkerInterface
@@ -178,17 +160,5 @@ final class HttpFoundationWorker implements HttpFoundationWorkerInterface
     private function timeFloat(): float
     {
         return microtime(true);
-    }
-
-    /**
-     * @param array<string, array<int, string|null>>|array<int, string|null> $headers
-     *
-     * @return array<int|string, string[]>
-     */
-    private function stringifyHeaders(array $headers): array
-    {
-        return array_map(static function ($headerValues) {
-            return array_map(static fn ($val) => (string) $val, (array) $headerValues);
-        }, $headers);
     }
 }

--- a/src/RoadRunnerBridge/HttpFoundationWorker/BufferedResponder.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker/BufferedResponder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
+
+use Spiral\RoadRunner\Http\HttpWorkerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class BufferedResponder implements HttpFoundationResponder
+{
+    public function supports(Response $response): bool
+    {
+        return true;
+    }
+
+    public function respond(HttpWorkerInterface $httpWorker, Response $response): void
+    {
+        $content = '';
+        ob_start(function ($buffer) use (&$content) {
+            $content .= $buffer;
+
+            return '';
+        });
+
+        $response->sendContent();
+        ob_end_clean();
+
+        $httpWorker->respond(
+            status: $response->getStatusCode(),
+            body: $content,
+            headers: HttpFoundationResponderHelper::stringifyHeaders($response->headers->all()),
+            endOfStream: true,
+        );
+    }
+}

--- a/src/RoadRunnerBridge/HttpFoundationWorker/ChainResponder.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker/ChainResponder.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
+
+use Spiral\RoadRunner\Http\HttpWorkerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ChainResponder implements HttpFoundationResponder
+{
+    /**
+     * @param iterable<HttpFoundationResponder> $responders
+     */
+    public function __construct(
+        private readonly iterable $responders,
+    ) {
+    }
+
+    public function supports(Response $response): bool
+    {
+        return (bool) $this->resolveResponder($response);
+    }
+
+    public function respond(HttpWorkerInterface $httpWorker, Response $response): void
+    {
+        $responder = $this->resolveResponder($response) ?? throw new \RuntimeException('Unsupported response.');
+        $responder->respond($httpWorker, $response);
+    }
+
+    private function resolveResponder(Response $response): ?HttpFoundationResponder
+    {
+        foreach ($this->responders as $responder) {
+            if ($responder->supports($response)) {
+                return $responder;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/RoadRunnerBridge/HttpFoundationWorker/ChunkedResponder.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker/ChunkedResponder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
+
+use Spiral\RoadRunner\Http\HttpWorkerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ChunkedResponder implements HttpFoundationResponder
+{
+    /**
+     * @param list<class-string<Response>> $responseClasses
+     * @param positive-int                 $chunkSize
+     */
+    public function __construct(
+        private readonly array $responseClasses,
+        private readonly int $chunkSize,
+    ) {
+    }
+
+    public function supports(Response $response): bool
+    {
+        return \in_array($response::class, $this->responseClasses, true);
+    }
+
+    public function respond(HttpWorkerInterface $httpWorker, Response $response): void
+    {
+        ob_start(function (string $buffer, int $phase) use ($response, $httpWorker) {
+            static $content = '';
+            $content .= $buffer;
+
+            $isFirst = ($phase & PHP_OUTPUT_HANDLER_START) === PHP_OUTPUT_HANDLER_START;
+            $isLast = ($phase & PHP_OUTPUT_HANDLER_END) === PHP_OUTPUT_HANDLER_END;
+
+            // Skip, if content size less, then chunk size
+            if (\strlen($content) < $this->chunkSize && !$isLast) {
+                return '';
+            }
+
+            $httpWorker->respond(
+                status: $response->getStatusCode(),
+                body: $content,
+                headers: $isFirst ? HttpFoundationResponderHelper::stringifyHeaders($response->headers->all()) : [],
+                endOfStream: $isLast,
+            );
+            $content = '';
+
+            return '';
+        }, $this->chunkSize);
+        $response->sendContent();
+        @ob_end_clean();
+    }
+}

--- a/src/RoadRunnerBridge/HttpFoundationWorker/HttpFoundationResponder.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker/HttpFoundationResponder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
+
+use Spiral\RoadRunner\Http\HttpWorkerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpFoundationResponder
+{
+    public function supports(Response $response): bool;
+
+    public function respond(HttpWorkerInterface $httpWorker, Response $response): void;
+}

--- a/src/RoadRunnerBridge/HttpFoundationWorker/HttpFoundationResponderHelper.php
+++ b/src/RoadRunnerBridge/HttpFoundationWorker/HttpFoundationResponderHelper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baldinof\RoadRunnerBundle\RoadRunnerBridge\HttpFoundationWorker;
+
+final class HttpFoundationResponderHelper
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, array<int, string|null>>|array<int, string|null> $headers
+     *
+     * @return array<int|string, string[]>
+     */
+    public static function stringifyHeaders(array $headers): array
+    {
+        return array_map(static function ($headerValues) {
+            return array_map(static fn ($val) => (string) $val, (array) $headerValues);
+        }, $headers);
+    }
+}

--- a/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
+++ b/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
@@ -315,12 +315,14 @@ final class RoadRunnerResponse
     public int $status;
     public string $content;
     public array $headers;
+    public bool $endOfStream;
 
-    public function __construct(int $status, string $content, array $headers)
+    public function __construct(int $status, string $content, array $headers, bool $endOfStream)
     {
         $this->status = $status;
         $this->content = $content;
         $this->headers = $headers;
+        $this->endOfStream = $endOfStream;
     }
 }
 
@@ -337,9 +339,9 @@ class MockWorker implements HttpWorkerInterface
         return $req;
     }
 
-    public function respond(int $status, string|\Generator $body, array $headers = []): void
+    public function respond(int $status, string|\Generator $body, array $headers = [], bool $endOfStream = true): void
     {
-        $this->responded = new RoadRunnerResponse($status, $body, $headers);
+        $this->responded = new RoadRunnerResponse($status, $body, $headers, $endOfStream);
     }
 
     public function getWorker(): WorkerInterface

--- a/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
+++ b/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Kernel;
 
 class HttpFoundationWorkerTest extends TestCase
 {
@@ -160,12 +161,22 @@ class HttpFoundationWorkerTest extends TestCase
 
         $innerWorker = new MockWorker();
 
-        $responder = new HttpFoundationWorker\ChainResponder([
-            new HttpFoundationWorker\ChunkedResponder([StreamedResponse::class, StreamedJsonResponse::class], 1024 * 16),
+        $innerResponders = [
+            new HttpFoundationWorker\ChunkedResponder([StreamedResponse::class], 1024 * 16),
             new HttpFoundationWorker\ChunkedResponder([BinaryFileResponse::class], 1),
-            new HttpFoundationWorker\ChunkedResponder([EventStreamResponse::class], 1),
-            new HttpFoundationWorker\BufferedResponder(),
-        ]);
+        ];
+
+        if (class_exists(StreamedJsonResponse::class)) {
+            $innerResponders[] = new HttpFoundationWorker\ChunkedResponder([StreamedJsonResponse::class], 1024 * 16);
+        }
+
+        if (class_exists(EventStreamResponse::class)) {
+            $innerResponders[] = new HttpFoundationWorker\ChunkedResponder([EventStreamResponse::class], 1);
+        }
+
+        $innerResponders[] = new HttpFoundationWorker\BufferedResponder();
+
+        $responder = new HttpFoundationWorker\ChainResponder($innerResponders);
         $worker = new HttpFoundationWorker($innerWorker, $responder);
 
         $worker->respond($sfResponse);
@@ -347,114 +358,120 @@ class HttpFoundationWorkerTest extends TestCase
             },
         ];
 
-        yield 'streamed response from chunks' => [
-            new StreamedResponse([
-                'foo',
-                ' ',
-                'bar baz',
-                ' ',
-                'qux',
-            ]),
-            2,
-            function (RoadRunnerResponse $response): void {
-                $this->assertSame(200, $response->status);
-                $this->assertSame('foo bar baz qux', $response->content);
-                $this->assertCount(4, $response->chunks);
-                $this->assertSame(['foo', ' bar baz', ' qux', ''], $response->chunks);
-            },
-        ];
+        // In symfony >= 7.3.0 StreamedResponse supports iterable<string> in argument $callbackOrChunks (prev $callback)
+        if (Kernel::VERSION_ID > 70300) {
+            yield 'streamed response from chunks' => [
+                new StreamedResponse([
+                    'foo',
+                    ' ',
+                    'bar baz',
+                    ' ',
+                    'qux',
+                ]),
+                2,
+                function (RoadRunnerResponse $response): void {
+                    $this->assertSame(200, $response->status);
+                    $this->assertSame('foo bar baz qux', $response->content);
+                    $this->assertCount(4, $response->chunks);
+                    $this->assertSame(['foo', ' bar baz', ' qux', ''], $response->chunks);
+                },
+            ];
 
-        yield 'streamed response from chunks 2' => [
-            new StreamedResponse([
-                'foo',
-                ' ',
-                'bar baz',
-                ' ',
-                'qux',
-            ]),
-            4,
-            function (RoadRunnerResponse $response): void {
-                $this->assertSame(200, $response->status);
-                $this->assertSame('foo bar baz qux', $response->content);
-                $this->assertCount(4, $response->chunks);
-                $this->assertSame(['foo ', 'bar baz', ' qux', ''], $response->chunks);
-            },
-        ];
+            yield 'streamed response from chunks 2' => [
+                new StreamedResponse([
+                    'foo',
+                    ' ',
+                    'bar baz',
+                    ' ',
+                    'qux',
+                ]),
+                4,
+                function (RoadRunnerResponse $response): void {
+                    $this->assertSame(200, $response->status);
+                    $this->assertSame('foo bar baz qux', $response->content);
+                    $this->assertCount(4, $response->chunks);
+                    $this->assertSame(['foo ', 'bar baz', ' qux', ''], $response->chunks);
+                },
+            ];
 
-        yield 'streamed response from chunks 3' => [
-            new StreamedResponse([
-                'foo',
-                ' ',
-                'bar baz',
-                ' ',
-                'qux',
-            ]),
-            1024 * 16,
-            function (RoadRunnerResponse $response): void {
-                $this->assertSame(200, $response->status);
-                $this->assertSame('foo bar baz qux', $response->content);
-                $this->assertCount(1, $response->chunks);
-                $this->assertSame(['foo bar baz qux'], $response->chunks);
-            },
-        ];
+            yield 'streamed response from chunks 3' => [
+                new StreamedResponse([
+                    'foo',
+                    ' ',
+                    'bar baz',
+                    ' ',
+                    'qux',
+                ]),
+                1024 * 16,
+                function (RoadRunnerResponse $response): void {
+                    $this->assertSame(200, $response->status);
+                    $this->assertSame('foo bar baz qux', $response->content);
+                    $this->assertCount(1, $response->chunks);
+                    $this->assertSame(['foo bar baz qux'], $response->chunks);
+                },
+            ];
+        }
 
-        yield 'streamed json response array' => [
-            function () {
-                $data = [];
+        // In symfony >= 6.3.0 supports StreamedJsonResponse
+        if (Kernel::VERSION_ID > 60300) {
+            yield 'streamed json response array' => [
+                function () {
+                    $data = [];
 
-                for ($i = 0; $i < 3; ++$i) {
-                    $data[] = ['id' => $i, 'data' => 'Some data value'];
-                }
+                    for ($i = 0; $i < 3; ++$i) {
+                        $data[] = ['id' => $i, 'data' => 'Some data value'];
+                    }
 
-                return new StreamedJsonResponse($data);
-            },
-            10,
-            function (RoadRunnerResponse $response): void {
-                $this->assertSame(200, $response->status);
-                $this->assertSame(
-                    '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
-                    $response->content,
-                );
-                $this->assertCount(2, $response->chunks);
-                $this->assertSame(
-                    [
+                    return new StreamedJsonResponse($data);
+                },
+                10,
+                function (RoadRunnerResponse $response): void {
+                    $this->assertSame(200, $response->status);
+                    $this->assertSame(
                         '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
-                        '',
-                    ],
-                    $response->chunks,
-                );
-            },
-        ];
+                        $response->content,
+                    );
+                    $this->assertCount(2, $response->chunks);
+                    $this->assertSame(
+                        [
+                            '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
+                            '',
+                        ],
+                        $response->chunks,
+                    );
+                },
+            ];
 
-        yield 'streamed json response iterable' => [
-            function () {
-                $data = [];
+            yield 'streamed json response iterable' => [
+                function () {
+                    $data = [];
 
-                for ($i = 0; $i < 3; ++$i) {
-                    $data[] = ['id' => $i, 'data' => 'Some data value'];
-                }
+                    for ($i = 0; $i < 3; ++$i) {
+                        $data[] = ['id' => $i, 'data' => 'Some data value'];
+                    }
 
-                return new StreamedJsonResponse(new \ArrayObject($data));
-            },
-            10,
-            function (RoadRunnerResponse $response): void {
-                $this->assertSame(200, $response->status);
-                $this->assertSame(
-                    '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
-                    $response->content,
-                );
-                $this->assertCount(4, $response->chunks);
-                $this->assertSame(
-                    [
-                        '[{"id":0,"data":"Some data value"}',
-                        ',{"id":1,"data":"Some data value"}',
-                        ',{"id":2,"data":"Some data value"}',
-                        ']',
-                    ],
-                    $response->chunks,
-                );
-            },
-        ];
+                    return new StreamedJsonResponse(new \ArrayObject($data));
+                },
+                10,
+                function (RoadRunnerResponse $response): void {
+                    $this->assertSame(200, $response->status);
+                    $this->assertSame(
+                        '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
+                        $response->content,
+                    );
+                    $this->assertCount(4, $response->chunks);
+                    $this->assertSame(
+                        [
+                            '[{"id":0,"data":"Some data value"}',
+                            ',{"id":1,"data":"Some data value"}',
+                            ',{"id":2,"data":"Some data value"}',
+                            ']',
+                        ],
+                        $response->chunks,
+                    );
+                },
+            ];
+        }
     }
 
     public function test_it_overrides_SERVER_global()

--- a/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
+++ b/tests/RoadRunnerBridge/HttpFoundationWorkerTest.php
@@ -13,9 +13,11 @@ use Spiral\RoadRunner\Http\Request as RoadRunnerRequest;
 use Spiral\RoadRunner\WorkerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class HttpFoundationWorkerTest extends TestCase
@@ -40,7 +42,7 @@ class HttpFoundationWorkerTest extends TestCase
         $innerWorker = new MockWorker();
         $innerWorker->nextRequest = $rrRequest;
 
-        $worker = new HttpFoundationWorker($innerWorker);
+        $worker = new HttpFoundationWorker($innerWorker, new HttpFoundationWorker\BufferedResponder());
         $symfonyRequest = $worker->waitRequest();
 
         $expectations($symfonyRequest);
@@ -149,8 +151,8 @@ class HttpFoundationWorkerTest extends TestCase
     /**
      * @dataProvider provideResponses
      *
-     * @param Response|(\Closure(): Response) $sfResponse
-     * @param \Closure<RoadRunnerResponse>: void $expectations
+     * @param Response|(\Closure(): Response)    $sfResponse
+     * @param \Closure(RoadRunnerResponse): void $expectations
      */
     public function test_it_convert_symfony_response_to_roadrunner($sfResponse, \Closure $expectations)
     {
@@ -158,13 +160,19 @@ class HttpFoundationWorkerTest extends TestCase
 
         $innerWorker = new MockWorker();
 
-        $worker = new HttpFoundationWorker($innerWorker);
+        $responder = new HttpFoundationWorker\ChainResponder([
+            new HttpFoundationWorker\ChunkedResponder([StreamedResponse::class, StreamedJsonResponse::class], 1024 * 16),
+            new HttpFoundationWorker\ChunkedResponder([BinaryFileResponse::class], 1),
+            new HttpFoundationWorker\ChunkedResponder([EventStreamResponse::class], 1),
+            new HttpFoundationWorker\BufferedResponder(),
+        ]);
+        $worker = new HttpFoundationWorker($innerWorker, $responder);
 
         $worker->respond($sfResponse);
 
         $this->assertNotNull($innerWorker->responded);
-
         $expectations($innerWorker->responded);
+        $this->assertTrue($innerWorker->responded->endOfStream);
     }
 
     public function provideResponses()
@@ -174,12 +182,16 @@ class HttpFoundationWorkerTest extends TestCase
             function (RoadRunnerResponse $roadRunnerResponse) {
                 $this->assertSame(200, $roadRunnerResponse->status);
                 $this->assertSame('', $roadRunnerResponse->content);
+                $this->assertCount(1, $roadRunnerResponse->chunks);
             },
         ];
 
         yield 'response with content' => [
             new Response('Hello world'),
-            fn (RoadRunnerResponse $response) => $this->assertSame('Hello world', $response->content),
+            function (RoadRunnerResponse $response) {
+                $this->assertSame('Hello world', $response->content);
+                $this->assertCount(1, $response->chunks);
+            },
         ];
 
         yield 'non 200 status code' => [
@@ -188,10 +200,13 @@ class HttpFoundationWorkerTest extends TestCase
         ];
 
         yield 'binary file response' => [
-            fn () => new BinaryFileResponse($this->createFile('binary-response.txt', 'hello')),
+            fn () => (new BinaryFileResponse($this->createFile('binary-response.txt', 'hello')))
+                ->setChunkSize(2),
             function (RoadRunnerResponse $roadRunnerResponse) {
                 $this->assertSame(200, $roadRunnerResponse->status);
                 $this->assertSame('hello', $roadRunnerResponse->content);
+                $this->assertCount(4, $roadRunnerResponse->chunks);
+                $this->assertSame(['he', 'll', 'o', ''], $roadRunnerResponse->chunks);
             },
         ];
 
@@ -215,6 +230,8 @@ class HttpFoundationWorkerTest extends TestCase
             function (RoadRunnerResponse $response) {
                 $this->assertSame(200, $response->status);
                 $this->assertSame('hello world', $response->content);
+                $this->assertCount(1, $response->chunks);
+                $this->assertSame(['hello world'], $response->chunks);
             },
         ];
 
@@ -253,6 +270,193 @@ class HttpFoundationWorkerTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideStreamedResponses
+     *
+     * @param StreamedResponse|(\Closure(): StreamedResponse) $sfResponse
+     * @param non-negative-int                                $chunkSize
+     * @param \Closure(RoadRunnerResponse): void              $expectations
+     */
+    public function test_it_convert_symfony_streamed_response_to_roadrunner(
+        StreamedResponse|\Closure $sfResponse,
+        int $chunkSize,
+        \Closure $expectations,
+    ): void {
+        $sfResponse = $sfResponse instanceof StreamedResponse ? $sfResponse : $sfResponse();
+
+        $innerWorker = new MockWorker();
+        $responder = new HttpFoundationWorker\ChunkedResponder([StreamedResponse::class, StreamedJsonResponse::class], $chunkSize);
+        $worker = new HttpFoundationWorker($innerWorker, $responder);
+        $worker->respond($sfResponse);
+
+        $this->assertNotNull($innerWorker->responded);
+        $expectations($innerWorker->responded);
+        $this->assertTrue($innerWorker->responded->endOfStream);
+    }
+
+    public function provideStreamedResponses(): iterable
+    {
+        yield 'streamed response from callback' => [
+            new StreamedResponse(function () {
+                echo 'foo';
+                echo ' ';
+                echo 'bar baz';
+                echo ' ';
+                echo 'qux';
+            }),
+            2,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(4, $response->chunks);
+                $this->assertSame(['foo', ' bar baz', ' qux', ''], $response->chunks);
+            },
+        ];
+
+        yield 'streamed response from callback 2' => [
+            new StreamedResponse(function () {
+                echo 'foo';
+                echo ' ';
+                echo 'bar baz';
+                echo ' ';
+                echo 'qux';
+            }),
+            4,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(4, $response->chunks);
+                $this->assertSame(['foo ', 'bar baz', ' qux', ''], $response->chunks);
+            },
+        ];
+
+        yield 'streamed response from callback 3' => [
+            new StreamedResponse(function () {
+                echo 'foo';
+                echo ' ';
+                echo 'bar baz';
+                echo ' ';
+                echo 'qux';
+            }),
+            1024 * 16,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(1, $response->chunks);
+                $this->assertSame(['foo bar baz qux'], $response->chunks);
+            },
+        ];
+
+        yield 'streamed response from chunks' => [
+            new StreamedResponse([
+                'foo',
+                ' ',
+                'bar baz',
+                ' ',
+                'qux',
+            ]),
+            2,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(4, $response->chunks);
+                $this->assertSame(['foo', ' bar baz', ' qux', ''], $response->chunks);
+            },
+        ];
+
+        yield 'streamed response from chunks 2' => [
+            new StreamedResponse([
+                'foo',
+                ' ',
+                'bar baz',
+                ' ',
+                'qux',
+            ]),
+            4,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(4, $response->chunks);
+                $this->assertSame(['foo ', 'bar baz', ' qux', ''], $response->chunks);
+            },
+        ];
+
+        yield 'streamed response from chunks 3' => [
+            new StreamedResponse([
+                'foo',
+                ' ',
+                'bar baz',
+                ' ',
+                'qux',
+            ]),
+            1024 * 16,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame('foo bar baz qux', $response->content);
+                $this->assertCount(1, $response->chunks);
+                $this->assertSame(['foo bar baz qux'], $response->chunks);
+            },
+        ];
+
+        yield 'streamed json response array' => [
+            function () {
+                $data = [];
+
+                for ($i = 0; $i < 3; ++$i) {
+                    $data[] = ['id' => $i, 'data' => 'Some data value'];
+                }
+
+                return new StreamedJsonResponse($data);
+            },
+            10,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame(
+                    '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
+                    $response->content,
+                );
+                $this->assertCount(2, $response->chunks);
+                $this->assertSame(
+                    [
+                        '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
+                        '',
+                    ],
+                    $response->chunks,
+                );
+            },
+        ];
+
+        yield 'streamed json response iterable' => [
+            function () {
+                $data = [];
+
+                for ($i = 0; $i < 3; ++$i) {
+                    $data[] = ['id' => $i, 'data' => 'Some data value'];
+                }
+
+                return new StreamedJsonResponse(new \ArrayObject($data));
+            },
+            10,
+            function (RoadRunnerResponse $response): void {
+                $this->assertSame(200, $response->status);
+                $this->assertSame(
+                    '[{"id":0,"data":"Some data value"},{"id":1,"data":"Some data value"},{"id":2,"data":"Some data value"}]',
+                    $response->content,
+                );
+                $this->assertCount(4, $response->chunks);
+                $this->assertSame(
+                    [
+                        '[{"id":0,"data":"Some data value"}',
+                        ',{"id":1,"data":"Some data value"}',
+                        ',{"id":2,"data":"Some data value"}',
+                        ']',
+                    ],
+                    $response->chunks,
+                );
+            },
+        ];
+    }
+
     public function test_it_overrides_SERVER_global()
     {
         $rrRequest = new RoadRunnerRequest(
@@ -266,7 +470,7 @@ class HttpFoundationWorkerTest extends TestCase
         $innerWorker = new MockWorker();
         $innerWorker->nextRequest = $rrRequest;
 
-        $worker = new HttpFoundationWorker($innerWorker);
+        $worker = new HttpFoundationWorker($innerWorker, new HttpFoundationWorker\BufferedResponder());
         $symfonyRequest = $worker->waitRequest();
 
         $this->assertSame('10.0.0.2', $symfonyRequest->server->get('REMOTE_ADDR'));
@@ -316,6 +520,8 @@ final class RoadRunnerResponse
     public string $content;
     public array $headers;
     public bool $endOfStream;
+    /** @var list<string> */
+    public array $chunks;
 
     public function __construct(int $status, string $content, array $headers, bool $endOfStream)
     {
@@ -323,6 +529,20 @@ final class RoadRunnerResponse
         $this->content = $content;
         $this->headers = $headers;
         $this->endOfStream = $endOfStream;
+        $this->chunks[] = $content;
+    }
+
+    public function withChunk(string $chunk, bool $endOfStream): self
+    {
+        $response = new self(
+            status: $this->status,
+            content: $this->content.$chunk,
+            headers: $this->headers,
+            endOfStream: $endOfStream,
+        );
+        $response->chunks = array_merge($this->chunks, [$chunk]);
+
+        return $response;
     }
 }
 
@@ -341,11 +561,19 @@ class MockWorker implements HttpWorkerInterface
 
     public function respond(int $status, string|\Generator $body, array $headers = [], bool $endOfStream = true): void
     {
-        $this->responded = new RoadRunnerResponse($status, $body, $headers, $endOfStream);
+        if ($body instanceof \Generator) {
+            throw new \LogicException('Generator body not supported.');
+        }
+
+        if (null === $this->responded || true === $this->responded->endOfStream) {
+            $this->responded = new RoadRunnerResponse($status, $body, $headers, $endOfStream);
+        } else {
+            $this->responded = $this->responded->withChunk($body, $endOfStream);
+        }
     }
 
     public function getWorker(): WorkerInterface
     {
-        throw new \Exception('Not implemented');
+        throw new \LogicException('Not implemented');
     }
 }


### PR DESCRIPTION
Closes #179 #130 #101

### 1. Updated `spiral/roadrunner-http` dependency to ^4.0

In this version, the `HttpWorkerInterface::respond()` method explicitly defines the `$endOfStream` parameter, allowing proper stream termination control.

### 2. Fixed streaming and file responses

- `StreamedResponse` (generators, echo callback)
- `StreamedJsonResponse`
- `EventStreamResponse`
- `BinaryFileResponse` (large files)

### 3. Created `HttpFoundationResponder` service

Responsible for sending responses based on their type. Implements flexible logic and serves as an extension point for future response types.

#### Implementations:

- `BufferedResponder` - returns the entire response from memory. Used  for simple responses and as a fallback.
- `ChunkedResponder` - splits the response into chunks and sends them to RoadRunner. Chunk size depends on response type:
  - `BinaryFileResponse` **1 byte** - Symfony itself streams the file in chunks, we don't interfere.
  - `EventStreamResponse` **1 byte** - for instant real-time event delivery.
  - `StreamedResponse`, `StreamedJsonResponse` **16 KB** -  same as default file chunk size. Can be overrides by `baldinof_road_runner.http_foundation_streamed_responder.chunk_size` parameter.
- `ChainResponder` - sequentially applies multiple responders (for complex cases)

Both main responders (`BufferedResponder` and `ChunkedResponder`) work through **output buffering interception** using `ob_start()`. This allows:
- Properly capturing data sent via `echo`, `print`, and other output functions
- Working with any response type without modifying the application code
- Maintaining compatibility with standard Symfony behavior

Added unit tests.

### 4. Results
- Eliminated connection resets and worker crashes during streaming
- Maintained performance at the level of the original bundle
- Established architecture for easy addition of new response types

#### Benchmarks

##### Streamed (1M records)

| Runtime  | Status   | Time         | Speed, M/s | Size, M    |
|----------|----------|--------------|------------|------------|
| rr       | ❌ 500    | 0.464        | 0          | 0          |
| rr-fork  | ✅ 200    | 0.410        | 153.4      | 62.8       |
| fpm      | ✅ 200    | 1.996        | 31.4       | 62.8       |

##### Streamed echo (1M records)

| Runtime  | Status   | Time         | Speed, M/s | Size, M    |
|----------|----------|--------------|------------|------------|
| rr       | ❌ 500    | 0.378        | 0          | 0          |
| rr-fork  | ✅ 200    | 0.385        | 163.1      | 62.8       |
| fpm      | ✅ 200    | 1.997        | 31.4       | 62.8       |

##### Streamed json (1M records)

| Runtime  | Status   | Time         | Speed, M/s | Size, M    |
|----------|----------|--------------|------------|------------|
| rr       | ❌ 500    | 0.445        | 0          | 0          |
| rr-fork  | ✅ 200    | 0.274        | 253.3      | 69.5       |
| fpm      | ✅ 200    | 0.288        | 241.5      | 69.5       |

##### File (60 Mb)

| Runtime  | Status   | Time         | Speed, M/s | Size, M    |
|----------|----------|--------------|------------|------------|
| rr       | ❌ 500    | 0.046        | 0          | 0          |
| rr-fork  | ✅ 200    | 0.057        | 1051.5     | 60.0       |
| fpm      | ✅ 200    | 0.082        | 730.5      | 60.0       |

##### Common

| Runtime  | Status   | Time         | Speed, M/s | Size, M    |
|----------|----------|--------------|------------|------------|
| rr       | ✅ 200    | 0.010        | 0          | 0          |
| rr-fork  | ✅ 200    | 0.001        | 0          | 0          |
| fpm      | ✅ 200    | 0.002        | 0          | 0          |

Benchmarks repository: https://github.com/Kenny1911/baldinof-roadrunner-bundle-streamed-response-benchmark