### PR TITLE
fix: reset() should be called after each request, not only on reboot

### DIFF
--- a/src/Worker/GrpcInvoker.php
+++ b/src/Worker/GrpcInvoker.php
@@ -78,23 +78,23 @@ final class GrpcInvoker implements InvokerInterface, GrpcTerminableInterface
             $this->gen = null;
         }
 
-        if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
-            try {
-                if ($this->kernel->getContainer()->has('services_resetter')) {
-                    /** @var ResetInterface $resetter */
-                    $resetter = $this->kernel->getContainer()->get('services_resetter');
-                    $resetter->reset();
-                }
-            } catch (\Throwable $e) {
-                $this->logger->error(
-                    \sprintf(
-                        'An error occurred when resetting services: %s',
-                        $e->getMessage()
-                    ),
-                    ['exception' => $e]
-                );
+        try {
+            if ($this->kernel->getContainer()->has('services_resetter')) {
+                /** @var ResetInterface $resetter */
+                $resetter = $this->kernel->getContainer()->get('services_resetter');
+                $resetter->reset();
             }
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                \sprintf(
+                    'An error occurred when resetting services: %s',
+                    $e->getMessage()
+                ),
+                ['exception' => $e]
+            );
+        }
 
+        if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
             $this->kernel->reboot(null);
             /** @var GrpcDependencies */
             $deps = $this->kernel->getContainer()->get(GrpcDependencies::class);

--- a/src/Worker/HttpWorker.php
+++ b/src/Worker/HttpWorker.php
@@ -144,23 +144,23 @@ final class HttpWorker implements WorkerInterface
                 $this->httpFoundationWorker->getWorker()->stop();
                 break;
             } finally {
-                if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
-                    try {
-                        if ($this->kernel->getContainer()->has('services_resetter')) {
-                            /** @var ResetInterface $resetter */
-                            $resetter = $this->kernel->getContainer()->get('services_resetter');
-                            $resetter->reset();
-                        }
-                    } catch (\Throwable $e) {
-                        $this->logger->error(
-                            \sprintf(
-                                'An error occurred when resetting services: %s',
-                                $e->getMessage()
-                            ),
-                            ['exception' => $e]
-                        );
+                try {
+                    if ($this->kernel->getContainer()->has('services_resetter')) {
+                        /** @var ResetInterface $resetter */
+                        $resetter = $this->kernel->getContainer()->get('services_resetter');
+                        $resetter->reset();
                     }
+                } catch (\Throwable $e) {
+                    $this->logger->error(
+                        \sprintf(
+                            'An error occurred when resetting services: %s',
+                            $e->getMessage()
+                        ),
+                        ['exception' => $e]
+                    );
+                }
 
+                if ($this->kernel instanceof RebootableInterface && $this->dependencies->getKernelRebootStrategy()->shouldReboot()) {
                     $this->kernel->reboot(null);
                     /** @var HttpDependencies */
                     $deps = $this->kernel->getContainer()->get(HttpDependencies::class);


### PR DESCRIPTION
service resetter is called before reboot, but in fact, it should be called after each request.

Inspired by symfony messenger, that will reset after each message handled, this make sense in the rationale described in the interface:

> Provides a way to reset an object to its initial state.
> When calling the "reset()" method on an object, it should be put back to its initial state. This usually means clearing any internal buffers and forwarding the call to internal dependencies. All properties of the object should be put back to the same state it had when it was first ready to use.
> This method could be called, for example, to recycle objects that are used as services, so that they can be used to handle several requests in the same process loop (note that we advise making your services stateless instead of implementing this interface when possible.)

Handling multiple requests in a loop is exactly what we do with roadrunner, even when we do not reboot the kernel entirely.